### PR TITLE
Only recognize well-known comment markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ allows for sorting data such as Go structs and JSON objects.
 #### Comments
 
 Comments embedded within the sorted block are made to stick with their
-successor. The comment lines must start with the same token as the
-keep-sorted instruction itself (e.g. `#` in the case below).
+successor. The comment lines must start with the same comment marker as the
+keep-sorted instruction itself (e.g. `#` in the case below). keep-sorted
+will recognize `//`, `/*`, `#`, `--`, `;`, and `<!--` as comment markers, for
+any other kinds of comments, use `sticky_prefixes`.
 
 This special handling can be disabled by specifying the parameter
 `sticky_comments=no`:

--- a/goldens/comments.in
+++ b/goldens/comments.in
@@ -42,3 +42,51 @@ Only non-sticky comments:
 // only
 // comments
 // keep-sorted-test end
+
+Slash-star-style comments:
+/* keep-sorted-test start */
+2
+1
+/* comment on 3 */
+3
+/* keep-sorted-test end */
+
+Dash-dash-style comments:
+-- keep-sorted-test start
+2
+1
+-- comment on 3
+3
+-- keep-sorted-test end
+
+Semicolon-style comments:
+; keep-sorted-test start
+2
+1
+; comment on 3
+3
+; keep-sorted-test end
+
+HTML-style comments:
+<!-- keep-sorted-test start -->
+2
+1
+<!-- comment on 3 -->
+3
+<!-- keep-sorted-test end -->
+
+Additional prefixes aren't counted as part of the comment:
+// some prefix (normally this is go/) keep-sorted-test start
+2
+1
+// comment on 3
+3
+// keep-sorted-test end
+
+Non-comment prefixes are still sorted:
+* keep-sorted-test start
+2
+1
+* not a comment on 3
+3
+* keep-sorted-test end

--- a/goldens/comments.out
+++ b/goldens/comments.out
@@ -42,3 +42,51 @@ Only non-sticky comments:
 // comments
 // only
 // keep-sorted-test end
+
+Slash-star-style comments:
+/* keep-sorted-test start */
+1
+2
+/* comment on 3 */
+3
+/* keep-sorted-test end */
+
+Dash-dash-style comments:
+-- keep-sorted-test start
+1
+2
+-- comment on 3
+3
+-- keep-sorted-test end
+
+Semicolon-style comments:
+; keep-sorted-test start
+1
+2
+; comment on 3
+3
+; keep-sorted-test end
+
+HTML-style comments:
+<!-- keep-sorted-test start -->
+1
+2
+<!-- comment on 3 -->
+3
+<!-- keep-sorted-test end -->
+
+Additional prefixes aren't counted as part of the comment:
+// some prefix (normally this is go/) keep-sorted-test start
+1
+2
+// comment on 3
+3
+// keep-sorted-test end
+
+Non-comment prefixes are still sorted:
+* keep-sorted-test start
+* not a comment on 3
+1
+2
+3
+* keep-sorted-test end

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -180,8 +180,21 @@ func parseValueWithDefault(f reflect.StructField, key, val string, defaultFn fun
 }
 
 func (f *Fixer) guessCommentMarker(startLine string) string {
-	sp := strings.SplitN(startLine, f.ID, 2)
-	return strings.TrimSpace(sp[0])
+	startLine = strings.TrimSpace(startLine)
+	if strings.HasPrefix(startLine, "//") {
+		return "//"
+	} else if strings.HasPrefix(startLine, "#") {
+		return "#"
+	} else if strings.HasPrefix(startLine, "/*") {
+		return "/*"
+	} else if strings.HasPrefix(startLine, "--") {
+		return "--"
+	} else if strings.HasPrefix(startLine, ";") {
+		return ";"
+	} else if strings.HasPrefix(startLine, "<!--") {
+		return "<!--"
+	}
+	return ""
 }
 
 // hasStickyPrefix determines if s has one of the StickyPrefixes.


### PR DESCRIPTION
Restricting what comment markers keep-sorted accepts leads to less surprising behavior, such as // go/keep-sorted treating the comment marker as "// go/" when using the default id of just "keep-sorted".