### PR TITLE
Allow for nested keep-sorted blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Surround the lines to keep sorted with `keep-sorted start` and
 <table border="0">
 <tr>
 <td>
-<h5>Before</h5>
+<b>Before</b>
 
 ```java
 @Component(
@@ -34,7 +34,7 @@ interface FrontendComponent {
 ```
 </td>
 <td>
-<h5>After</h5>
+<b>After</b>
 
 ```diff
 @Component(
@@ -51,6 +51,57 @@ interface FrontendComponent {
 interface FrontendComponent {
   FrontendRequestHandler requestHandler();
 }
+```
+</td>
+</tr>
+</table>
+
+You can also nest keep-sorted blocks:
+
+<table border="0">
+<tr>
+<td>
+
+<!-- Including a long blank line here so that the code block width is more
+consistent -->
+```python
+                              
+foo = [
+
+  'y',
+  'x',
+  'z',
+
+]
+bar = [
+
+  '1',
+  '3',
+  '2',
+
+]
+
+```
+</td>
+<td>
+
+```diff
++# keep-sorted start block=yes
+ bar = [
++  # keep-sorted start
+   '1',
+   '2',
+   '3',
++  # keep-sorted end
+ ]
+ foo = [
++  # keep-sorted start
+   'x',
+   'y',
+   'z',
++  # keep-sorted end
+ ]
++# keep-sorted end
 ```
 </td>
 </tr>

--- a/goldens/group.in
+++ b/goldens/group.in
@@ -101,3 +101,21 @@ Indented markdown lists:
      * Philosophical conjecture
 
 <!-- keep-sorted-test end -->
+
+Nested keep-sorted
+// keep-sorted-test start group=yes
+private static final List<String> b = [
+  // keep-sorted-test start
+  "x",
+  "z",
+  "y"
+  // keep-sorted-test end
+  ];
+private static final List<String> a = [
+  // keep-sorted-test start
+  "3",
+  "2",
+  "1"
+  // keep-sorted-test end
+  ];
+// keep-sorted-test end

--- a/goldens/group.in
+++ b/goldens/group.in
@@ -119,3 +119,21 @@ private static final List<String> a = [
   // keep-sorted-test end
   ];
 // keep-sorted-test end
+
+Nested keep-sorted, nested blocks change their number of lines.
+// keep-sorted-test start group=yes
+private static final List<String> b = [
+  // keep-sorted-test start
+  "x",
+  "x",
+  "y"
+  // keep-sorted-test end
+  ];
+private static final List<String> a = [
+  // keep-sorted-test start newline_separated=yes
+  "3",
+  "2",
+  "1"
+  // keep-sorted-test end
+  ];
+// keep-sorted-test end

--- a/goldens/group.out
+++ b/goldens/group.out
@@ -103,17 +103,19 @@ Indented markdown lists:
 <!-- keep-sorted-test end -->
 
 Nested keep-sorted
+// keep-sorted-test start group=yes
+private static final List<String> a = [
+  // keep-sorted-test start
+  "3",
+  "2",
+  "1"
+  // keep-sorted-test end
+  ];
 private static final List<String> b = [
   // keep-sorted-test start
   "x",
-  "y",
-  "z"
+  "z",
+  "y"
   // keep-sorted-test end
   ];
-private static final List<String> a = [
-  // keep-sorted-test start
-  "1",
-  "2",
-  "3"
-  // keep-sorted-test end
-  ];
+// keep-sorted-test end

--- a/goldens/group.out
+++ b/goldens/group.out
@@ -106,15 +106,34 @@ Nested keep-sorted
 // keep-sorted-test start group=yes
 private static final List<String> a = [
   // keep-sorted-test start
-  "3",
+  "1",
   "2",
-  "1"
+  "3"
   // keep-sorted-test end
   ];
 private static final List<String> b = [
   // keep-sorted-test start
   "x",
-  "z",
+  "y",
+  "z"
+  // keep-sorted-test end
+  ];
+// keep-sorted-test end
+
+Nested keep-sorted, nested blocks change their number of lines.
+// keep-sorted-test start group=yes
+private static final List<String> a = [
+  // keep-sorted-test start newline_separated=yes
+  "1",
+
+  "2",
+
+  "3"
+  // keep-sorted-test end
+  ];
+private static final List<String> b = [
+  // keep-sorted-test start
+  "x",
   "y"
   // keep-sorted-test end
   ];

--- a/goldens/group.out
+++ b/goldens/group.out
@@ -101,3 +101,19 @@ Indented markdown lists:
      * Wise insight
 
 <!-- keep-sorted-test end -->
+
+Nested keep-sorted
+private static final List<String> b = [
+  // keep-sorted-test start
+  "x",
+  "y",
+  "z"
+  // keep-sorted-test end
+  ];
+private static final List<String> a = [
+  // keep-sorted-test start
+  "1",
+  "2",
+  "3"
+  // keep-sorted-test end
+  ];

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -27,7 +27,15 @@ type block struct {
 	opts blockOptions
 
 	start, end int
-	lines      []string
+	// lines are the content of this block from the original file.
+	//
+	// Do not modify this slice:
+	// This slice shares the same backing array as every other keep-sorted block
+	// in this file.  That same backing array is also used by Fixer.Fix to
+	// generate the fixed file content. Modifying the backing array might have
+	// unintended effects on other (nested) blocks. Modifying the backing array
+	// will have unintended effects on Fixer.Fix.
+	lines []string
 
 	nestedBlocks []block
 }
@@ -63,8 +71,10 @@ func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end in
 		index int
 		line  string
 	}
-	// Stacks of startLines and nested blocks.
+	// starts is a stack of startLines.
 	var starts []startLine
+	// nestedBlocks by nesting level. nestedBlocks[0] is the slice of blocks that
+	// are nested under the current top-level block.
 	var nestedBlocks [][]block
 	for i, l := range lines {
 		if strings.Contains(l, f.startDirective) {
@@ -100,6 +110,8 @@ func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end in
 				log.Err(fmt.Errorf("keep-sorted block at index %d had bad start directive: %w", start.index+offset, err)).Msg("")
 			}
 
+			// Top-level keep-sorted directives have depth 0. Nested keep-sorted
+			// directives will have depth >= 1 based on how deep it is.
 			depth := len(starts)
 			block := block{
 				opts:  opts,
@@ -107,24 +119,39 @@ func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end in
 				end:   endIndex + offset,
 				lines: lines[start.index+1 : endIndex],
 			}
+			// For example, consider depth=0:
+			// If we just finished a top-level block and there are first-level nested
+			// blocks present, we need to remove those from nestedBlocks and include
+			// them on this block.
+			// It isn't possible for len(nestedBlocks) to be > depth+1:
+			// At depth n, n != 0, we increase the length of nestedBlocks to be n.
+			// At depth m=n-1, the length of nestedBlocks will initially be n=m+1 (the assertion from above)
+			// and then we trim that down to be length m when we add the nested blocks
+			// to the current block.
 			if len(nestedBlocks) == depth+1 {
 				block.nestedBlocks = nestedBlocks[depth]
 				nestedBlocks = nestedBlocks[0:depth]
 			}
 			if depth == 0 {
+				// Top-level blocks get returned.
+				// Nested blocks are returned via their top-level block.
 				blocks = append(blocks, block)
 			} else {
+				// Otherwise, the current block appears to be nested. Add it to nestedBlocks.
 				for len(nestedBlocks) < depth {
 					nestedBlocks = append(nestedBlocks, nil)
 				}
 				nestedBlocks[depth-1] = append(nestedBlocks[depth-1], block)
 			}
+			// Invariant: len(nestedBlocks) == depth
 		}
 	}
 	if len(starts) > 0 {
 		for _, st := range starts {
 			incompleteBlocks = append(incompleteBlocks, incompleteBlock{st.index + offset, startDirective})
 		}
+		// There were some unfinished start directives. They might've caused some
+		// blocks to be incorrectly considered nested.
 		for _, nested := range nestedBlocks {
 			blocks = append(blocks, nested...)
 		}
@@ -133,8 +160,70 @@ func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end in
 	return blocks, incompleteBlocks
 }
 
+// sorted returns a slice which represents the correct sorting of b.lines.
+// If b.lines is already correctly sorted, we will return b.lines, true.
 func (b block) sorted() (sorted []string, alreadySorted bool) {
-	groups := groupLines(b.lines, b.opts)
+	alreadySorted = true
+
+	// Sort the nested blocks first so that their changes are visible to the
+	// outer block.
+	type nestedResult struct {
+		lines         []string
+		alreadySorted bool
+	}
+	var nestedResults []nestedResult
+	for _, n := range b.nestedBlocks {
+		lines, already := n.sorted()
+		if !already {
+			alreadySorted = false
+		}
+		nestedResults = append(nestedResults, nestedResult{lines, already})
+	}
+
+	lines := b.lines
+	if !alreadySorted {
+		var lineChunks [][]string
+		// The total number of lines in lineChunks.
+		var numLines int
+		// Our current position within lines.
+		var cursor int
+		for i, nested := range b.nestedBlocks {
+			res := nestedResults[i]
+			if res.alreadySorted {
+				// This nested block was already sorted. Its content in lines is already
+				// correct. We will add this block to lineChunks either as an unchanged
+				// prefix to a changed nested block, or as the remainder of lines if there
+				// are no more changed nested blocks.
+				continue
+			}
+
+			offset := nested.start - b.start
+			// Unchanged prefix of lines.
+			lineChunks = append(lineChunks, lines[cursor:offset])
+			numLines += offset - cursor
+			// The piece of the nested block that changed.
+			lineChunks = append(lineChunks, res.lines)
+			numLines += len(res.lines)
+
+			// Advance cursor to the end of the nested block within lines.
+			cursor = offset + len(nested.lines)
+		}
+
+		if rem := lines[cursor:]; len(rem) > 0 {
+			// Are there any lines remaining in lines after handing all the nested
+			// blocks?
+			lineChunks = append(lineChunks, rem)
+			numLines += len(rem)
+		}
+
+		// See above for the scary comment telling us not to modify b.lines directly.
+		lines = make([]string, 0, numLines)
+		for _, chunk := range lineChunks {
+			lines = append(lines, chunk...)
+		}
+	}
+
+	groups := groupLines(lines, b.opts)
 	log.Printf("%d groups for block at index %d are (options %#v)", len(groups), b.start, b.opts)
 	for _, lg := range groups {
 		log.Printf("%#v", lg)
@@ -172,9 +261,9 @@ func (b block) sorted() (sorted []string, alreadySorted bool) {
 
 	less := b.lessFn()
 
-	if wasNewlineSeparated && !removedDuplicate && slices.IsSortedFunc(groups, less) {
+	if alreadySorted && wasNewlineSeparated && !removedDuplicate && slices.IsSortedFunc(groups, less) {
 		trimTrailingComma(groups)
-		return b.lines, true
+		return lines, true
 	}
 
 	slices.SortStableFunc(groups, less)
@@ -193,7 +282,7 @@ func (b block) sorted() (sorted []string, alreadySorted bool) {
 		groups = separated
 	}
 
-	l := make([]string, 0, len(b.lines))
+	l := make([]string, 0, len(lines))
 	for _, g := range groups {
 		l = append(l, g.allLines()...)
 	}

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -43,10 +43,10 @@ var (
 
 // initZerolog initializes zerolog to log as part of the test.
 // It returns a function that restores zerolog to its state before this function was called.
-func initZerolog(t testing.TB) func() {
+func initZerolog(t testing.TB) {
 	oldLogger := log.Logger
 	log.Logger = log.Output(zerolog.NewTestWriter(t))
-	return func() { log.Logger = oldLogger }
+	t.Cleanup(func() { log.Logger = oldLogger })
 }
 
 func defaultOptionsWith(f func(*blockOptions)) blockOptions {
@@ -180,7 +180,7 @@ foo
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer initZerolog(t)() // Note the extra parens.
+			initZerolog(t)
 			got, gotAlreadyFixed := New("keep-sorted-test").Fix(tc.in, nil)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Fix diff (-want +got):\n%s", diff)
@@ -301,7 +301,7 @@ baz
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer initZerolog(t)() // Note the extra parens.
+			initZerolog(t)
 			var mod []LineRange
 			if tc.modifiedLines != nil {
 				for _, l := range tc.modifiedLines {
@@ -636,7 +636,7 @@ dog
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer initZerolog(t)() // Note the extra parens.
+			initZerolog(t)
 			if tc.include == nil {
 				tc.include = func(start, end int) bool { return true }
 			}
@@ -1064,7 +1064,7 @@ func TestLineSorting(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer initZerolog(t)() // Note the extra parens.
+			initZerolog(t)
 			got, gotAlreadySorted := block{lines: tc.in, opts: tc.opts}.sorted()
 			if gotAlreadySorted != tc.wantAlreadySorted {
 				t.Errorf("alreadySorted mismatch: got %t want %t", gotAlreadySorted, tc.wantAlreadySorted)
@@ -1354,7 +1354,7 @@ func TestLineGrouping(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer initZerolog(t)() // Note the extra parens.
+			initZerolog(t)
 			var in []string
 			for _, lg := range tc.want {
 				in = append(in, lg.comment...)
@@ -1445,7 +1445,7 @@ func TestBlockOptions(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer initZerolog(t)() // Note the extra parens.
+			initZerolog(t)
 			got, err := New("keep-sorted-test").parseBlockOptions(tc.in)
 			if err != nil {
 				if tc.wantErr == "" {

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -39,6 +41,14 @@ var (
 	}
 )
 
+// initZerolog initializes zerolog to log as part of the test.
+// It returns a function that restores zerolog to its state before this function was called.
+func initZerolog(t testing.TB) func() {
+	oldLogger := log.Logger
+	log.Logger = log.Output(zerolog.NewTestWriter(t))
+	return func() { log.Logger = oldLogger }
+}
+
 func defaultOptionsWith(f func(*blockOptions)) blockOptions {
 	opts := defaultOptions
 	f(&opts)
@@ -55,7 +65,7 @@ func TestFix(t *testing.T) {
 		wantAlreadyFixed bool
 	}{
 		{
-			name: "empty",
+			name: "Empty",
 
 			in: `
 // keep-sorted-test start
@@ -67,7 +77,7 @@ func TestFix(t *testing.T) {
 			wantAlreadyFixed: true,
 		},
 		{
-			name: "already sorted",
+			name: "AlreadySorted",
 
 			in: `
 // keep-sorted-test start
@@ -85,7 +95,7 @@ func TestFix(t *testing.T) {
 			wantAlreadyFixed: true,
 		},
 		{
-			name: "unordered block",
+			name: "UnorderedBlock",
 
 			in: `
 // keep-sorted-test start
@@ -102,7 +112,7 @@ func TestFix(t *testing.T) {
 // keep-sorted-test end`,
 		},
 		{
-			name: "unmatched start",
+			name: "UnmatchedStart",
 
 			in: `
 // keep-sorted-test start
@@ -120,7 +130,7 @@ func TestFix(t *testing.T) {
 // keep-sorted-test end`,
 		},
 		{
-			name: "unmatched end",
+			name: "UnmatchedEnd",
 
 			in: `
 // keep-sorted-test start
@@ -139,7 +149,7 @@ func TestFix(t *testing.T) {
 `,
 		},
 		{
-			name: "multiple fixes",
+			name: "MultipleFixes",
 
 			in: `
 // keep-sorted-test end
@@ -170,6 +180,7 @@ foo
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			defer initZerolog(t)() // Note the extra parens.
 			got, gotAlreadyFixed := New("keep-sorted-test").Fix(tc.in, nil)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Fix diff (-want +got):\n%s", diff)
@@ -193,7 +204,7 @@ func TestFindings(t *testing.T) {
 		want []*Finding
 	}{
 		{
-			name: "already sorted",
+			name: "AlreadySorted",
 
 			in: `
 // keep-sorted-test start
@@ -205,7 +216,7 @@ func TestFindings(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "not sorted",
+			name: "NotSorted",
 
 			in: `
 // keep-sorted-test start
@@ -217,7 +228,7 @@ func TestFindings(t *testing.T) {
 			want: []*Finding{finding(filename, 3, 5, errorUnordered, "1\n2\n3\n")},
 		},
 		{
-			name: "mismatched start",
+			name: "MismatchedStart",
 
 			in: `
 // keep-sorted-test start`,
@@ -225,7 +236,7 @@ func TestFindings(t *testing.T) {
 			want: []*Finding{finding(filename, 2, 2, "This instruction doesn't have matching 'keep-sorted-test end' line", "")},
 		},
 		{
-			name: "mismatched end",
+			name: "MismatchedEnd",
 
 			in: `
 // keep-sorted-test end`,
@@ -233,7 +244,7 @@ func TestFindings(t *testing.T) {
 			want: []*Finding{finding(filename, 2, 2, "This instruction doesn't have matching 'keep-sorted-test start' line", "")},
 		},
 		{
-			name: "multiple findings",
+			name: "MultipleFindings",
 
 			in: `
 // keep-sorted-test end
@@ -258,7 +269,7 @@ baz
 			},
 		},
 		{
-			name: "modified lines",
+			name: "ModifiedLines",
 
 			in: `
 // keep-sorted-test start
@@ -290,6 +301,7 @@ baz
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			defer initZerolog(t)() // Note the extra parens.
 			var mod []LineRange
 			if tc.modifiedLines != nil {
 				for _, l := range tc.modifiedLines {
@@ -315,7 +327,7 @@ func TestCreatingBlocks(t *testing.T) {
 		wantIncompleteBlocks []incompleteBlock
 	}{
 		{
-			name: "multiple blocks",
+			name: "MultipleBlocks",
 
 			in: `
 foo
@@ -358,9 +370,10 @@ cat`,
 			},
 		},
 		{
-			name: "incomplete blocks",
+			name: "IncompleteBlocks",
 
 			in: `
+// keep-sorted-test end
 // keep-sorted-test start
 foo
 bar
@@ -368,26 +381,25 @@ bar
 baz
 // keep-sorted-test end
 dog
-// keep-sorted-test end
 `,
 
 			wantBlocks: []block{
 				{
 					opts:  defaultOptions,
-					start: 4,
-					end:   6,
+					start: 5,
+					end:   7,
 					lines: []string{
 						"baz",
 					},
 				},
 			},
 			wantIncompleteBlocks: []incompleteBlock{
-				{1, startDirective},
-				{8, endDirective},
+				{1, endDirective},
+				{2, startDirective},
 			},
 		},
 		{
-			name: "filtered blocks",
+			name: "FilteredBlocks",
 
 			in: `
 foo
@@ -423,7 +435,7 @@ cat`,
 			},
 		},
 		{
-			name: "trailing newlines",
+			name: "TrailingNewlines",
 
 			in: `
 // keep-sorted-test start
@@ -453,6 +465,7 @@ cat`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			defer initZerolog(t)() // Note the extra parens.
 			if tc.include == nil {
 				tc.include = func(start, end int) bool { return true }
 			}
@@ -479,7 +492,7 @@ func TestLineSorting(t *testing.T) {
 		wantAlreadySorted bool
 	}{
 		{
-			name: "nothing to sort",
+			name: "NothingToSort",
 
 			opts: defaultOptions,
 			in:   []string{},
@@ -488,7 +501,7 @@ func TestLineSorting(t *testing.T) {
 			wantAlreadySorted: true,
 		},
 		{
-			name: "already sorted",
+			name: "AlreadySorted",
 
 			opts: defaultOptions,
 			in: []string{
@@ -507,7 +520,7 @@ func TestLineSorting(t *testing.T) {
 			wantAlreadySorted: true,
 		},
 		{
-			name: "already sorted -- except for duplicate",
+			name: "AlreadySorted_ExceptForDuplicate",
 
 			opts: defaultOptions,
 			in: []string{
@@ -523,7 +536,7 @@ func TestLineSorting(t *testing.T) {
 			wantAlreadySorted: false,
 		},
 		{
-			name: "already sorted -- newline separated",
+			name: "AlreadySorted_NewlineSeparated",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.NewlineSeparated = true
@@ -546,7 +559,7 @@ func TestLineSorting(t *testing.T) {
 			wantAlreadySorted: true,
 		},
 		{
-			name: "already sorted -- except for newline separated",
+			name: "AlreadySorted_ExceptForNewlineSorted",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.NewlineSeparated = true
@@ -567,7 +580,7 @@ func TestLineSorting(t *testing.T) {
 			wantAlreadySorted: false,
 		},
 		{
-			name: "simple sorting",
+			name: "SimpleSorting",
 
 			opts: defaultOptions,
 			in: []string{
@@ -585,7 +598,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "comment only block",
+			name: "CommentOnlyBlock",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.StickyComments = true
@@ -604,7 +617,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "prefix",
+			name: "Prefix",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.PrefixOrder = []string{"INIT_", "", "FINAL_"}
@@ -630,7 +643,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "remove duplicates -- by default",
+			name: "RemoveDuplicates_ByDefault",
 
 			opts: defaultOptions,
 			in: []string{
@@ -645,7 +658,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "remove duplicates -- considers comments",
+			name: "RemoveDuplicates_ConsidersComments",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.RemoveDuplicates = true
@@ -671,7 +684,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "remove duplicates -- ignores trailing commas",
+			name: "RemoveDuplicates_IgnoresTraliningCommas",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.RemoveDuplicates = true
@@ -688,7 +701,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "remove duplicates -- ignores trailing commas -- removes comma if last element",
+			name: "RemoveDuplicates_IgnoresTrailingCommas_RemovesCommaIfLastElement",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.RemoveDuplicates = true
@@ -705,7 +718,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "remove duplicates -- ignores trailing commas -- removes comma if only element",
+			name: "RemoveDuplicates_IgnoresTrailingCommas_RemovesCommaIfOnlyElement",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.RemoveDuplicates = true
@@ -720,7 +733,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "remove duplicates -- keep",
+			name: "RemoveDuplicates_Keep",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.RemoveDuplicates = false
@@ -738,7 +751,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "trailing commas",
+			name: "TrailingCommas",
 
 			opts: defaultOptions,
 			in: []string{
@@ -754,7 +767,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "ignore prefixes",
+			name: "IgnorePrefixes",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.IgnorePrefixes = []string{"fs.setBoolFlag", "fs.setIntFlag"}
@@ -774,7 +787,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "case insensitive",
+			name: "CaseInsensitive",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.CaseSensitive = false
@@ -794,7 +807,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "numeric",
+			name: "Numeric",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Numeric = true
@@ -818,7 +831,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple transforms",
+			name: "MultipleTransforms",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.IgnorePrefixes = []string{"R2D2", "C3PO", "R4"}
@@ -847,7 +860,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "newline separated",
+			name: "NewlineSeparated",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.NewlineSeparated = true
@@ -868,7 +881,7 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
-			name: "newline separated -- empty",
+			name: "NewlineSeparated_Empty",
 
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.NewlineSeparated = true
@@ -880,6 +893,7 @@ func TestLineSorting(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			defer initZerolog(t)() // Note the extra parens.
 			got, gotAlreadySorted := block{lines: tc.in, opts: tc.opts}.sorted()
 			if gotAlreadySorted != tc.wantAlreadySorted {
 				t.Errorf("alreadySorted mismatch: got %t want %t", gotAlreadySorted, tc.wantAlreadySorted)
@@ -896,10 +910,11 @@ func TestLineGrouping(t *testing.T) {
 		name string
 		opts blockOptions
 
+		// We set the input to be the concatenation of all the lineGroups.
 		want []lineGroup
 	}{
 		{
-			name: "simple",
+			name: "Simple",
 			opts: defaultOptions,
 
 			want: []lineGroup{
@@ -908,7 +923,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "sticky comments",
+			name: "StickyComments",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.StickyComments = true
 				opts.StickyPrefixes = map[string]bool{"//": true}
@@ -934,7 +949,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "comment only group",
+			name: "CommentOnlyGroup",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.StickyComments = true
 				opts.StickyPrefixes = map[string]bool{"//": true}
@@ -958,7 +973,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "group",
+			name: "Group",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Group = true
 			}),
@@ -997,7 +1012,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "block -- brackets",
+			name: "Block_Brackets",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true
 			}),
@@ -1018,7 +1033,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "block -- quotes",
+			name: "Block_Quotes",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true
 			}),
@@ -1039,7 +1054,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "block -- escaped quote",
+			name: "Block_EscapedQuote",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true
 			}),
@@ -1060,7 +1075,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "block -- ignores quotes within quotes",
+			name: "Block_IgnoresQuotesWithinQuotes",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true
 			}),
@@ -1081,7 +1096,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "block -- ignores braces within quotes",
+			name: "Block_IgnoresBracesWithinQuotes",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true
 			}),
@@ -1102,7 +1117,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "block -- ignores special characters within full-line comments",
+			name: "Block_IgnoresSpecialCharactersWithinFullLineComments",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true
 				opts.StickyPrefixes["//"] = true
@@ -1126,7 +1141,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "block -- ignores special characters within trailing comments",
+			name: "Block_IgnoresSpecialCharactersWithinTrailingComments",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true
 				opts.StickyPrefixes["//"] = true
@@ -1152,7 +1167,7 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
-			name: "block -- triple quotes",
+			name: "Block_TripleQuotes",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true
 			}),
@@ -1168,6 +1183,7 @@ func TestLineGrouping(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			defer initZerolog(t)() // Note the extra parens.
 			var in []string
 			for _, lg := range tc.want {
 				in = append(in, lg.comment...)
@@ -1191,13 +1207,13 @@ func TestBlockOptions(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "default options",
+			name: "DefaultOptions",
 			in:   "// keep-sorted-test",
 
 			want: defaultOptions,
 		},
 		{
-			name: "simple switch",
+			name: "SimpleSwitch",
 			in:   "// keep-sorted-test lint=no",
 
 			want: defaultOptionsWith(func(opts *blockOptions) {
@@ -1205,7 +1221,7 @@ func TestBlockOptions(t *testing.T) {
 			}),
 		},
 		{
-			name: "item list",
+			name: "ItemList",
 			in:   "// keep-sorted-test prefix_order=a,b,c,d",
 
 			want: defaultOptionsWith(func(opts *blockOptions) {
@@ -1213,7 +1229,7 @@ func TestBlockOptions(t *testing.T) {
 			}),
 		},
 		{
-			name: "item set",
+			name: "ItemSet",
 			in:   "keep-sorted-test sticky_prefixes=a,b,c,d",
 
 			want: defaultOptionsWith(func(opts *blockOptions) {
@@ -1230,7 +1246,7 @@ func TestBlockOptions(t *testing.T) {
 			}),
 		},
 		{
-			name: "ignore_prefixes checks longest prefixes first",
+			name: "ignore_prefixes_ChecksLognestPrefixesFirst",
 			in:   "// keep-sorted-test ignore_prefixes=DoSomething(,DoSomething({",
 
 			want: defaultOptionsWith(func(opts *blockOptions) {
@@ -1238,7 +1254,7 @@ func TestBlockOptions(t *testing.T) {
 			}),
 		},
 		{
-			name: "option in a trailing comment",
+			name: "OptionInTrailingComment",
 			in:   "// keep-sorted-test block=yes  # lint=no",
 
 			want: defaultOptionsWith(func(opts *blockOptions) {
@@ -1247,7 +1263,7 @@ func TestBlockOptions(t *testing.T) {
 			}),
 		},
 		{
-			name: "error doesn't stop parsing",
+			name: "ErrorDoesNotStopParsing",
 			in:   "// keep-sorted-test lint=yep case=no",
 
 			want: defaultOptionsWith(func(opts *blockOptions) {
@@ -1258,6 +1274,7 @@ func TestBlockOptions(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			defer initZerolog(t)() // Note the extra parens.
 			got, err := New("keep-sorted-test").parseBlockOptions(tc.in)
 			if err != nil {
 				if tc.wantErr == "" {

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -468,12 +468,17 @@ cat`,
 
 			in: `
 // keep-sorted-test start
-foo
-bar
+a
+b
+c
 // keep-sorted-test start
-baz
+d
+e
+f
 // keep-sorted-test end
-dog
+g
+h
+i
 // keep-sorted-test end
 `,
 
@@ -481,22 +486,29 @@ dog
 				{
 					opts:  defaultOptions,
 					start: 1,
-					end:   8,
+					end:   13,
 					lines: []string{
-						"foo",
-						"bar",
+						"a",
+						"b",
+						"c",
 						"// keep-sorted-test start",
-						"baz",
+						"d",
+						"e",
+						"f",
 						"// keep-sorted-test end",
-						"dog",
+						"g",
+						"h",
+						"i",
 					},
 					nestedBlocks: []block{
 						{
 							opts:  defaultOptions,
-							start: 4,
-							end:   6,
+							start: 5,
+							end:   9,
 							lines: []string{
-								"baz",
+								"d",
+								"e",
+								"f",
 							},
 						},
 					},
@@ -509,89 +521,154 @@ dog
 			in: `
 // keep-sorted-test start
 0.1
+0.2
+0.3
 // keep-sorted-test start
-1
+1.1
+1.2
+1.3
 // keep-sorted-test start
 2.1
-// keep-sorted-test start
-3
-// keep-sorted-test end // 3
-// keep-sorted-test end // 2.1
-// keep-sorted-test start
 2.2
-// keep-sorted-test end // 2.2
-// keep-sorted-test end // 1
-// keep-sorted-test end // 0.1
+2.3
 // keep-sorted-test start
-0.2
-// keep-sorted-test end // 0.2
+3.1
+3.2
+3.3
+// keep-sorted-test end // 0:1:2:3
+2.4
+2.5
+2.6
+// keep-sorted-test end // 0:1:2
+// keep-sorted-test start
+4.1
+4.2
+4.3
+// keep-sorted-test end // 0:1:4
+1.4
+1.5
+1.6
+// keep-sorted-test end // 0:1
+0.4
+0.5
+0.6
+// keep-sorted-test end // 0
+// keep-sorted-test start
+5.1
+5.2
+5.3
+// keep-sorted-test end // 5
 `,
 
 			wantBlocks: []block{
 				{
 					opts:  defaultOptions,
 					start: 1,
-					end:   15,
+					end:   34,
 					lines: []string{
 						"0.1",
+						"0.2",
+						"0.3",
 						"// keep-sorted-test start",
-						"1",
+						"1.1",
+						"1.2",
+						"1.3",
 						"// keep-sorted-test start",
 						"2.1",
-						"// keep-sorted-test start",
-						"3",
-						"// keep-sorted-test end // 3",
-						"// keep-sorted-test end // 2.1",
-						"// keep-sorted-test start",
 						"2.2",
-						"// keep-sorted-test end // 2.2",
-						"// keep-sorted-test end // 1",
+						"2.3",
+						"// keep-sorted-test start",
+						"3.1",
+						"3.2",
+						"3.3",
+						"// keep-sorted-test end // 0:1:2:3",
+						"2.4",
+						"2.5",
+						"2.6",
+						"// keep-sorted-test end // 0:1:2",
+						"// keep-sorted-test start",
+						"4.1",
+						"4.2",
+						"4.3",
+						"// keep-sorted-test end // 0:1:4",
+						"1.4",
+						"1.5",
+						"1.6",
+						"// keep-sorted-test end // 0:1",
+						"0.4",
+						"0.5",
+						"0.6",
 					},
 					nestedBlocks: []block{
 						{
 							opts:  defaultOptions,
-							start: 3,
-							end:   14,
+							start: 5,
+							end:   30,
 							lines: []string{
-								"1",
+								"1.1",
+								"1.2",
+								"1.3",
 								"// keep-sorted-test start",
 								"2.1",
-								"// keep-sorted-test start",
-								"3",
-								"// keep-sorted-test end // 3",
-								"// keep-sorted-test end // 2.1",
-								"// keep-sorted-test start",
 								"2.2",
-								"// keep-sorted-test end // 2.2",
+								"2.3",
+								"// keep-sorted-test start",
+								"3.1",
+								"3.2",
+								"3.3",
+								"// keep-sorted-test end // 0:1:2:3",
+								"2.4",
+								"2.5",
+								"2.6",
+								"// keep-sorted-test end // 0:1:2",
+								"// keep-sorted-test start",
+								"4.1",
+								"4.2",
+								"4.3",
+								"// keep-sorted-test end // 0:1:4",
+								"1.4",
+								"1.5",
+								"1.6",
 							},
 							nestedBlocks: []block{
 								{
 									opts:  defaultOptions,
-									start: 5,
-									end:   10,
+									start: 9,
+									end:   21,
 									lines: []string{
 										"2.1",
+										"2.2",
+										"2.3",
 										"// keep-sorted-test start",
-										"3",
-										"// keep-sorted-test end // 3",
+										"3.1",
+										"3.2",
+										"3.3",
+										"// keep-sorted-test end // 0:1:2:3",
+										"2.4",
+										"2.5",
+										"2.6",
 									},
 									nestedBlocks: []block{
 										{
 											opts:  defaultOptions,
-											start: 7,
-											end:   9,
+											start: 13,
+											end:   17,
 											lines: []string{
-												"3",
+												"3.1",
+												"3.2",
+												"3.3",
 											},
 										},
 									},
 								},
 								{
 									opts:  defaultOptions,
-									start: 11,
-									end:   13,
+									start: 22,
+									end:   26,
 									lines: []string{
-										"2.2",
+										"4.1",
+										"4.2",
+										"4.3",
 									},
 								},
 							},
@@ -600,10 +677,12 @@ dog
 				},
 				{
 					opts:  defaultOptions,
-					start: 16,
-					end:   18,
+					start: 35,
+					end:   39,
 					lines: []string{
-						"0.2",
+						"5.1",
+						"5.2",
+						"5.3",
 					},
 				},
 			},


### PR DESCRIPTION
Note: There's a couple different commits in this PR. The first commit contains a golden test that shows the behavior of keep-sorted before this PR.