### PR TITLE
Let newlines be considered for grouping if the next non-empty line has the proper indent.

### DIFF
--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -974,6 +974,29 @@ func TestLineGrouping(t *testing.T) {
 			},
 		},
 		{
+			name: "Group_UnindentedNewlines",
+			opts: defaultOptionsWith(func(opts *blockOptions) {
+				opts.Group = true
+			}),
+
+			want: []lineGroup{
+				{nil, []string{
+					"  foo",
+					"", // Since the next non-empty line has the correct indent.
+					"    bar",
+				}},
+				{nil, []string{
+					"", // Next non-empty line has the wrong indent.
+				}},
+				{nil, []string{
+					"  baz",
+				}},
+				{nil, []string{
+					"", // There is no next non-empty line.
+				}},
+			},
+		},
+		{
 			name: "block -- brackets",
 			opts: defaultOptionsWith(func(opts *blockOptions) {
 				opts.Block = true


### PR DESCRIPTION
This is necessary for a nested keep-sorted test case (#14) that uses group=yes to capture the nested keep-sorted blocks as well as newline_separated=yes in one of those nested blocks.

Without this, the newlines that the nested block introduces break up the indent-based grouping, resulting in pretty bad behavior.