### PR TITLE
Have pre-commit bootstrap go so that GitHub actions don't need to

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,9 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.21"
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
     hooks:
       - id: keep-sorted
         name: keep-sorted
-        language: system
-        entry: go
-        args: [run, .]
+        language: golang
+        # Remember to also update language_version in .pre-commit-hooks.yaml!
+        language_version: 1.21.6
+        entry: go run .
+  - repo: https://github.com/pre-commit/pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: validate_manifest

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,5 @@
 - id: keep-sorted
   name: keep-sorted
   language: golang
+  language_version: 1.21.6
   entry: keep-sorted


### PR DESCRIPTION
It looks like GitHub actions only use go 1.20 by default, so anyone using keep-sorted via the GitHub action pre-commit would need to separately install go 1.21. It looks like pre-commit can do that for us automatically.

See https://github.com/google/keep-sorted/pull/18#discussion_r1450679143 for more details

Tested in a child PR https://github.com/google/keep-sorted/pull/22