### PR TITLE
refactor(options): Define default options as an explicit instance.

### DIFF
--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -109,7 +109,7 @@ func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end in
 				continue
 			}
 
-			opts, err := f.parseBlockOptions(start.line)
+			opts, err := f.parseBlockOptions(start.line, defaultOptions)
 			if err != nil {
 				// TODO(b/250608236): Is there a better way to surface this error?
 				log.Err(fmt.Errorf("keep-sorted block at index %d had bad start directive: %w", start.index+offset, err)).Msg("")


### PR DESCRIPTION
This simplifies option parsing logic a bit, and sets us up to add a flag to override the default options (https://github.com/google/keep-sorted/pull/35).

I also tweaked most of the tests in keep_sorted_test to not rely on the default options at all and instead be more explicit about the behavior they need to pass.