### PR TITLE
feat: Surface option parsing warnings via findings.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -224,7 +224,13 @@ func fix(fixer *keepsorted.Fixer, filenames []string, modifiedLines []keepsorted
 				return false, err
 			}
 			for _, warn := range warnings {
-				log.Warn().Str("file", warn.Path).Int("start", warn.Lines.Start).Int("end", warn.Lines.End).Msg(warn.Message)
+				log := log.Warn().Str("file", warn.Path)
+				if warn.Lines.Start == warn.Lines.End {
+					log = log.Int("line", warn.Lines.Start)
+				} else {
+					log = log.Int("start", warn.Lines.Start).Int("end", warn.Lines.End)
+				}
+				log.Msg(warn.Message)
 			}
 		}
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/google/keep-sorted/keepsorted"
+	"github.com/rs/zerolog/log"
 	flag "github.com/spf13/pflag"
 )
 
@@ -218,9 +219,12 @@ func fix(fixer *keepsorted.Fixer, filenames []string, modifiedLines []keepsorted
 		if err != nil {
 			return false, err
 		}
-		if want, alreadyFixed := fixer.Fix(contents, modifiedLines); fn == stdin || !alreadyFixed {
+		if want, alreadyFixed, warnings := fixer.Fix(fn, contents, modifiedLines); fn == stdin || !alreadyFixed {
 			if err := write(fn, want); err != nil {
 				return false, err
+			}
+			for _, warn := range warnings {
+				log.Warn().Str("file", warn.Path).Int("start", warn.Lines.Start).Int("end", warn.Lines.End).Msg(warn.Message)
 			}
 		}
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -224,7 +224,10 @@ func fix(fixer *keepsorted.Fixer, filenames []string, modifiedLines []keepsorted
 				return false, err
 			}
 			for _, warn := range warnings {
-				log := log.Warn().Str("file", warn.Path)
+				log := log.Warn()
+				if warn.Path != stdin {
+					log = log.Str("file", warn.Path)
+				}
 				if warn.Lines.Start == warn.Lines.End {
 					log = log.Int("line", warn.Lines.Start)
 				} else {

--- a/goldens/generate-goldens.sh
+++ b/goldens/generate-goldens.sh
@@ -18,13 +18,15 @@
 set -euo pipefail
 [[ -n "${DEBUG:-}" ]] && set -x
 
-files=()
-for i in "$@"; do
-  o="${i%%in}out"
-  cp "${i}" "${i%%in}out"
-  files+=( "$o" )
-done
-
 dir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 git_dir="$(git -C "${dir}" rev-parse --show-toplevel)"
-go run "${git_dir}" --id=keep-sorted-test -- "${files[@]}"
+
+for i in "$@"; do
+  out="${i%%in}out"
+  err="${i%%in}err"
+
+  go run "${git_dir}" --id=keep-sorted-test --omit-timestamps - < "${i}" >"${out}" 2>"${err}"
+  if (( $(wc -l < "${err}") == 0 )); then
+    rm "${err}"
+  fi
+done

--- a/goldens/generate-goldens.sh
+++ b/goldens/generate-goldens.sh
@@ -25,7 +25,7 @@ for i in "$@"; do
   out="${i%%in}out"
   err="${i%%in}err"
 
-  go run "${git_dir}" --id=keep-sorted-test --omit-timestamps - < "${i}" >"${out}" 2>"${err}"
+  go run "${git_dir}" --id=keep-sorted-test --omit-timestamps - <"${i}" >"${out}" 2>"${err}"
   if (( $(wc -l < "${err}") == 0 )); then
     rm "${err}"
   fi

--- a/goldens/simple.err
+++ b/goldens/simple.err
@@ -1,2 +1,2 @@
-WRN unrecognized option "foo" file=- line=105
 WRN skip_lines has invalid value: -1 file=- line=105
+WRN unrecognized option "foo" file=- line=105

--- a/goldens/simple.err
+++ b/goldens/simple.err
@@ -1,0 +1,2 @@
+WRN unrecognized option "foo" file=- line=105
+WRN skip_lines has invalid value: -1 file=- line=105

--- a/goldens/simple.err
+++ b/goldens/simple.err
@@ -1,2 +1,2 @@
-WRN skip_lines has invalid value: -1 file=- line=105
-WRN unrecognized option "foo" file=- line=105
+WRN skip_lines has invalid value: -1 line=105
+WRN unrecognized option "foo" line=105

--- a/goldens/simple.in
+++ b/goldens/simple.in
@@ -107,6 +107,3 @@ Invalid option
   1
   3
   keep-sorted-test end
-
-STDERR: unrecognized option "foo" end=105
-STDERR: skip_lines has invalid value: -1 end=105

--- a/goldens/simple.in
+++ b/goldens/simple.in
@@ -100,3 +100,13 @@ A
 
 B
 // keep-sorted-test end
+
+Invalid option
+  keep-sorted-test start group=yes skip_lines=-1 foo=bar
+  2
+  1
+  3
+  keep-sorted-test end
+
+STDERR: unrecognized option "foo" end=105
+STDERR: skip_lines has invalid value: -1 end=105

--- a/goldens/simple.out
+++ b/goldens/simple.out
@@ -106,6 +106,3 @@ Invalid option
   2
   3
   keep-sorted-test end
-
-STDERR: unrecognized option "foo" end=105
-STDERR: skip_lines has invalid value: -1 end=105

--- a/goldens/simple.out
+++ b/goldens/simple.out
@@ -99,3 +99,13 @@ B
 
 C
 // keep-sorted-test end
+
+Invalid option
+  keep-sorted-test start group=yes skip_lines=-1 foo=bar
+  1
+  2
+  3
+  keep-sorted-test end
+
+STDERR: unrecognized option "foo" end=105
+STDERR: skip_lines has invalid value: -1 end=105

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -16,7 +16,6 @@ package keepsorted
 
 import (
 	"cmp"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -68,9 +67,10 @@ const (
 // include is a function that lets the caller determine if a particular block
 // should be included in the result. Mostly useful for filtering keep-sorted
 // blocks to just the ones that were modified by the currently CL.
-func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end int) bool) ([]block, []incompleteBlock) {
+func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end int) bool) ([]block, []incompleteBlock, map[int]optionWarnings) {
 	var blocks []block
 	var incompleteBlocks []incompleteBlock
+	warnsByLine := make(map[int]optionWarnings)
 
 	type startLine struct {
 		index int
@@ -110,10 +110,9 @@ func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end in
 			}
 
 			commentMarker, options, _ := strings.Cut(start.line, f.startDirective)
-			opts, err := parseBlockOptions(commentMarker, options, f.defaultOptions)
-			if err != nil {
-				// TODO(b/250608236): Is there a better way to surface this error?
-				log.Err(fmt.Errorf("keep-sorted block at index %d had bad start directive: %w", start.index+offset, err)).Msg("")
+			opts, optionWarnings := parseBlockOptions(commentMarker, options, f.defaultOptions)
+			if len(optionWarnings) > 0 {
+				warnsByLine[start.index+offset] = optionWarnings
 			}
 
 			start.index += opts.SkipLines
@@ -172,7 +171,7 @@ func (f *Fixer) newBlocks(lines []string, offset int, include func(start, end in
 		}
 	}
 
-	return blocks, incompleteBlocks
+	return blocks, incompleteBlocks, warnsByLine
 }
 
 // sorted returns a slice which represents the correct sorting of b.lines.

--- a/keepsorted/keep_sorted.go
+++ b/keepsorted/keep_sorted.go
@@ -17,7 +17,6 @@ package keepsorted
 import (
 	"cmp"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -132,9 +131,10 @@ type Replacement struct {
 }
 
 func (f *Fixer) findings(filename string, contents []string, modifiedLines []LineRange, considerLintOption bool) []*Finding {
-	blocks, incompleteBlocks, warns := f.newBlocks(contents, 1, includeModifiedLines(modifiedLines))
+	blocks, incompleteBlocks, warns := f.newBlocks(filename, contents, 1, includeModifiedLines(modifiedLines))
 
 	var fs []*Finding
+	fs = append(fs, warns...)
 	for _, b := range blocks {
 		if considerLintOption && !b.metadata.opts.Lint {
 			continue
@@ -154,11 +154,6 @@ func (f *Fixer) findings(filename string, contents []string, modifiedLines []Lin
 			panic(fmt.Errorf("unknown directive type: %v", ib.dir))
 		}
 		fs = append(fs, finding(filename, ib.line, ib.line, msg, replacement(ib.line, ib.line, "")))
-	}
-	for _, line := range slices.Sorted(maps.Keys(warns)) {
-		for _, warn := range warns[line] {
-			fs = append(fs, finding(filename, line, line, warn.Error()))
-		}
 	}
 
 	slices.SortFunc(fs, func(a, b *Finding) int {

--- a/keepsorted/keep_sorted.go
+++ b/keepsorted/keep_sorted.go
@@ -17,6 +17,7 @@ package keepsorted
 import (
 	"cmp"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -56,16 +57,21 @@ func (f *Fixer) errorMissingEnd() string {
 }
 
 // Fix all of the findings on contents to make keep-sorted happy.
-func (f *Fixer) Fix(contents string, modifiedLines []LineRange) (fixed string, alreadyCorrect bool) {
+func (f *Fixer) Fix(filename, contents string, modifiedLines []LineRange) (fixed string, alreadyCorrect bool, warnings []*Finding) {
 	lines := strings.Split(contents, "\n")
-	fs := f.findings("unused-filename", lines, modifiedLines, false)
+	fs := f.findings(filename, lines, modifiedLines, false)
 	if len(fs) == 0 {
-		return contents, true
+		return contents, true, nil
 	}
 
 	var s strings.Builder
 	startLine := 1
 	for _, f := range fs {
+		if len(f.Fixes) == 0 {
+			warnings = append(warnings, f)
+			continue
+		}
+
 		repl := f.Fixes[0].Replacements[0]
 		endLine := repl.Lines.Start
 
@@ -77,7 +83,7 @@ func (f *Fixer) Fix(contents string, modifiedLines []LineRange) (fixed string, a
 	}
 	s.WriteString(strings.Join(lines[startLine-1:], "\n"))
 
-	return s.String(), false
+	return s.String(), false, warnings
 }
 
 // Findings returns a slice of things that need to be addressed in the file to
@@ -126,7 +132,7 @@ type Replacement struct {
 }
 
 func (f *Fixer) findings(filename string, contents []string, modifiedLines []LineRange, considerLintOption bool) []*Finding {
-	blocks, incompleteBlocks := f.newBlocks(contents, 1, includeModifiedLines(modifiedLines))
+	blocks, incompleteBlocks, warns := f.newBlocks(contents, 1, includeModifiedLines(modifiedLines))
 
 	var fs []*Finding
 	for _, b := range blocks {
@@ -134,7 +140,7 @@ func (f *Fixer) findings(filename string, contents []string, modifiedLines []Lin
 			continue
 		}
 		if s, alreadySorted := b.sorted(); !alreadySorted {
-			fs = append(fs, finding(filename, b.start+1, b.end-1, errorUnordered, linesToString(s)))
+			fs = append(fs, finding(filename, b.start+1, b.end-1, errorUnordered, replacement(b.start+1, b.end-1, linesToString(s))))
 		}
 	}
 	for _, ib := range incompleteBlocks {
@@ -147,7 +153,12 @@ func (f *Fixer) findings(filename string, contents []string, modifiedLines []Lin
 		default:
 			panic(fmt.Errorf("unknown directive type: %v", ib.dir))
 		}
-		fs = append(fs, finding(filename, ib.line, ib.line, msg, ""))
+		fs = append(fs, finding(filename, ib.line, ib.line, msg, replacement(ib.line, ib.line, "")))
+	}
+	for _, line := range slices.Sorted(maps.Keys(warns)) {
+		for _, warn := range warns[line] {
+			fs = append(fs, finding(filename, line, line, warn.Error()))
+		}
 	}
 
 	slices.SortFunc(fs, func(a, b *Finding) int {
@@ -178,30 +189,35 @@ func linesToString(lines []string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-func finding(filename string, start, end int, msg, replace string) *Finding {
-	lr := LineRange{
-		Start: start,
-		End:   end,
-	}
+func finding(filename string, start, end int, msg string, fixes ...Fix) *Finding {
 	return &Finding{
 		Path:    filename,
-		Lines:   lr,
+		Lines:   lineRange(start, end),
 		Message: msg,
-		Fixes: []Fix{
+		Fixes:   fixes,
+	}
+}
+
+func replacement(start, end int, s string) Fix {
+	return Fix{
+		Replacements: []Replacement{
 			{
-				Replacements: []Replacement{
-					{
-						Lines:      lr,
-						NewContent: replace,
-					},
-				},
+				Lines:      lineRange(start, end),
+				NewContent: s,
 			},
 		},
 	}
 }
 
+func lineRange(start, end int) LineRange {
+	return LineRange{
+		Start: start,
+		End:   end,
+	}
+}
+
 func startLine(f *Finding) int {
-	return f.Fixes[0].Replacements[0].Lines.Start
+	return f.Lines.Start
 }
 
 var _ augmentedtree.Interval = LineRange{}

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -37,8 +37,8 @@ func DefaultBlockOptions() BlockOptions {
 }
 
 func ParseBlockOptions(options string) (BlockOptions, error) {
-	opts, err := parseBlockOptions( /*commentMarker=*/ "", options, blockOptions{})
-	if err != nil {
+	opts, warns := parseBlockOptions( /*commentMarker=*/ "", options, blockOptions{})
+	if err := warns.err(); err != nil {
 		return BlockOptions{}, err
 	}
 	return BlockOptions{opts}, nil
@@ -139,10 +139,17 @@ func key(f reflect.StructField) string {
 	return key
 }
 
-func parseBlockOptions(commentMarker, options string, defaults blockOptions) (blockOptions, error) {
+// optionWarnings are things that we found wrong with the option string but don't need to halt the entire keep-sorted operation.
+type optionWarnings []error
+
+func (warns optionWarnings) err() error {
+	return errors.Join(warns...)
+}
+
+func parseBlockOptions(commentMarker, options string, defaults blockOptions) (blockOptions, optionWarnings) {
 	ret := defaults
 	opts := reflect.ValueOf(&ret).Elem()
-	var errs []error
+	var warns optionWarnings
 	parser := &parser{options}
 	for {
 		key, ok := parser.popKey()
@@ -151,14 +158,14 @@ func parseBlockOptions(commentMarker, options string, defaults blockOptions) (bl
 		}
 		fieldIdx, ok := fieldIndexByKey[key]
 		if !ok {
-			errs = append(errs, fmt.Errorf("unrecognized option %q", key))
+			warns = append(warns, fmt.Errorf("unrecognized option %q", key))
 			continue
 		}
 
 		field := opts.Field(fieldIdx)
 		val, err := parser.popValue(field.Type())
 		if err != nil {
-			errs = append(errs, fmt.Errorf("while parsing option %q: %w", key, err))
+			warns = append(warns, fmt.Errorf("while parsing option %q: %w", key, err))
 			continue
 		}
 		field.Set(val)
@@ -172,11 +179,11 @@ func parseBlockOptions(commentMarker, options string, defaults blockOptions) (bl
 		slices.SortFunc(ret.IgnorePrefixes, func(a string, b string) int { return cmp.Compare(len(b), len(a)) })
 	}
 
-	if err := validate(&ret); err != nil {
-		errs = append(errs, err)
+	if warn := validate(&ret); len(warn) > 0 {
+		warns = append(warns, warn...)
 	}
 
-	return ret, errors.Join(errs...)
+	return ret, warns
 }
 
 func formatValue(val reflect.Value) string {
@@ -222,19 +229,19 @@ func (opts *blockOptions) setCommentMarker(marker string) {
 	}
 }
 
-func validate(opts *blockOptions) error {
-	var errs []error
+func validate(opts *blockOptions) optionWarnings {
+	var warns optionWarnings
 	if opts.SkipLines < 0 {
-		errs = append(errs, fmt.Errorf("skip_lines has invalid value: %v", opts.SkipLines))
+		warns = append(warns, fmt.Errorf("skip_lines has invalid value: %v", opts.SkipLines))
 		opts.SkipLines = 0
 	}
 
 	if opts.GroupPrefixes != nil && !opts.Group {
-		errs = append(errs, fmt.Errorf("group_prefixes may not be used with group=no"))
+		warns = append(warns, fmt.Errorf("group_prefixes may not be used with group=no"))
 		opts.GroupPrefixes = nil
 	}
 
-	return errors.Join(errs...)
+	return warns
 }
 
 func (opts blockOptions) String() string {

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -150,8 +150,8 @@ func TestBlockOptions(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			initZerolog(t)
-			got, err := parseBlockOptions(tc.commentMarker, tc.in, tc.defaultOptions)
-			if err != nil {
+			got, warns := parseBlockOptions(tc.commentMarker, tc.in, tc.defaultOptions)
+			if err := warns.err(); err != nil {
 				if tc.wantErr == "" {
 					t.Errorf("parseBlockOptions(%q, %q) = %v", tc.commentMarker, tc.in, err)
 				} else if !strings.Contains(err.Error(), tc.wantErr) {
@@ -171,8 +171,8 @@ func TestBlockOptions_ClonesDefaultOptions(t *testing.T) {
 	defaults := blockOptions{
 		StickyPrefixes: map[string]bool{},
 	}
-	_, err := parseBlockOptions("", "sticky_prefixes=//", defaults)
-	if err != nil {
+	_, warns := parseBlockOptions("", "sticky_prefixes=//", defaults)
+	if err := warns.err(); err != nil {
 		t.Errorf("parseBlockOptions() = _, %v", err)
 	}
 	if diff := cmp.Diff(blockOptions{}, defaults, cmp.AllowUnexported(blockOptions{}), cmpopts.EquateEmpty()); diff != "" {

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -15,6 +15,7 @@
 package keepsorted
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -151,7 +152,7 @@ func TestBlockOptions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			initZerolog(t)
 			got, warns := parseBlockOptions(tc.commentMarker, tc.in, tc.defaultOptions)
-			if err := warns.err(); err != nil {
+			if err := errors.Join(warns...); err != nil {
 				if tc.wantErr == "" {
 					t.Errorf("parseBlockOptions(%q, %q) = %v", tc.commentMarker, tc.in, err)
 				} else if !strings.Contains(err.Error(), tc.wantErr) {
@@ -172,7 +173,7 @@ func TestBlockOptions_ClonesDefaultOptions(t *testing.T) {
 		StickyPrefixes: map[string]bool{},
 	}
 	_, warns := parseBlockOptions("", "sticky_prefixes=//", defaults)
-	if err := warns.err(); err != nil {
+	if err := errors.Join(warns...); err != nil {
 		t.Errorf("parseBlockOptions() = _, %v", err)
 	}
 	if diff := cmp.Diff(blockOptions{}, defaults, cmp.AllowUnexported(blockOptions{}), cmpopts.EquateEmpty()); diff != "" {


### PR DESCRIPTION
These findings have no fix. I suppose we could recommend that they remove the invalid text, but I think just surfacing the warning should be enough. These show up as findings when linting and stderr warnings when fixing.