### PR TITLE
fix: Calculate the initial indent correctly in a couple edge cases.

### DIFF
--- a/goldens/group.in
+++ b/goldens/group.in
@@ -1,24 +1,24 @@
 Group indented lines:
-public class Foo {
-  // keep-sorted-test start group=yes
-  private final Foo foo;
-  private final Bar bar;
-  private final Baz baz =
-      new Baz();
-  private final Qux qux;
-  // keep-sorted-test end
-}
+  public class Foo {
+    // keep-sorted-test start group=yes
+    private final Foo foo;
+    private final Bar bar;
+    private final Baz baz =
+        new Baz();
+    private final Qux qux;
+    // keep-sorted-test end
+  }
 
 Same thing but it's tabs:
-public class Foo {
-	// keep-sorted-test start group=yes
-	private final Foo foo;
-	private final Bar bar;
-	private final Baz baz =
-			new Baz();
-	private final Qux qux;
-	// keep-sorted-test end
-}
+  public class Foo {
+  	// keep-sorted-test start group=yes
+  	private final Foo foo;
+  	private final Bar bar;
+  	private final Baz baz =
+  			new Baz();
+  	private final Qux qux;
+  	// keep-sorted-test end
+  }
 
 Do not count indent from empty lines:
   // keep-sorted-test start
@@ -29,130 +29,162 @@ Do not count indent from empty lines:
   // keep-sorted-test end
 
 Multiple indentions:
-public class Foo {
-  // keep-sorted-test start group=yes
-  private final Foo foo;
-  private final Bar bar;
-  private final Baz baz =
-      new
-          Baz();
-  private final Qux qux;
-  // keep-sorted-test end
-}
+  public class Foo {
+    // keep-sorted-test start group=yes
+    private final Foo foo;
+    private final Bar bar;
+    private final Baz baz =
+        new
+            Baz();
+    private final Qux qux;
+    // keep-sorted-test end
+  }
 
 With sticky comments:
-public class Foo {
-  // keep-sorted-test start group=yes sticky_comments=yes
-  private final Foo foo;
-  private final Bar bar;
-  // What a long line!
-  private final Baz baz =
-      new Baz();
-  private final Qux qux;
-  // keep-sorted-test end
-}
+  public class Foo {
+    // keep-sorted-test start group=yes sticky_comments=yes
+    private final Foo foo;
+    private final Bar bar;
+    // What a long line!
+    private final Baz baz =
+        new Baz();
+    private final Qux qux;
+    // keep-sorted-test end
+  }
 
 Sorting doesn't take newline into account
-// keep-sorted-test start group=yes
-line 4
-line
-  3
-line
-  1
-line 2
-// keep-sorted-test end
+  // keep-sorted-test start group=yes
+  line 4
+  line
+    3
+  line
+    1
+  line 2
+  // keep-sorted-test end
 
 With list separator
-// keep-sorted-test start group=yes
-Foo foo,
-Bar bar,
-Baz
-    baz
-// keep-sorted-test end
+  // keep-sorted-test start group=yes
+  Foo foo,
+  Bar bar,
+  Baz
+      baz
+  // keep-sorted-test end
 
 Without whitespace on unbroken lines
-// keep-sorted-test start group=yes
-SomeLongEnumTypeNameWithLongValueNames.D_SHORT_VALUE
-SomeLongEnumTypeNameWithLongValueNames
-    .C_SOME_LONG_ENUM_VALUE_THAT_REQUIRES_A_LINE_BREAK
-SomeLongEnumTypeNameWithLongValueNames.B_SHORT_VALUE
-SomeLongEnumTypeNameWithLongValueNames
-    .A_SOME_LONG_ENUM_VALUE_THAT_REQUIRES_A_LINE_BREAK
-// keep-sorted-test end
+  // keep-sorted-test start group=yes
+  SomeLongEnumTypeNameWithLongValueNames.D_SHORT_VALUE
+  SomeLongEnumTypeNameWithLongValueNames
+      .C_SOME_LONG_ENUM_VALUE_THAT_REQUIRES_A_LINE_BREAK
+  SomeLongEnumTypeNameWithLongValueNames.B_SHORT_VALUE
+  SomeLongEnumTypeNameWithLongValueNames
+      .A_SOME_LONG_ENUM_VALUE_THAT_REQUIRES_A_LINE_BREAK
+  // keep-sorted-test end
 
 Without grouping:
-public class Foo {
-  // keep-sorted-test start group=no
-  private final Foo foo;
-  private final Bar bar;
-  private final Baz baz =
-      new Baz();
-  private final Qux qux;
-  // keep-sorted-test end
-}
+  public class Foo {
+    // keep-sorted-test start group=no
+    private final Foo foo;
+    private final Bar bar;
+    private final Baz baz =
+        new Baz();
+    private final Qux qux;
+    // keep-sorted-test end
+  }
 
 Indented markdown lists:
-<!-- keep-sorted-test start group=yes -->
-
- * Foo
-     * Wise insight
- * Bar
- * Baz
-     * Philosophical conjecture
-
-<!-- keep-sorted-test end -->
+  <!-- keep-sorted-test start group=yes -->
+  
+   * Foo
+       * Wise insight
+   * Bar
+   * Baz
+       * Philosophical conjecture
+  
+  <!-- keep-sorted-test end -->
 
 Nested keep-sorted
-// keep-sorted-test start group=yes
-private static final List<String> b = [
-  // keep-sorted-test start
-  "x",
-  "z",
-  "y"
+  // keep-sorted-test start group=yes
+  private static final List<String> b = [
+    // keep-sorted-test start
+    "x",
+    "z",
+    "y"
+    // keep-sorted-test end
+    ];
+  private static final List<String> a = [
+    // keep-sorted-test start
+    "3",
+    "2",
+    "1"
+    // keep-sorted-test end
+    ];
   // keep-sorted-test end
-  ];
-private static final List<String> a = [
-  // keep-sorted-test start
-  "3",
-  "2",
-  "1"
-  // keep-sorted-test end
-  ];
-// keep-sorted-test end
 
 Nested keep-sorted, nested blocks change their number of lines.
-// keep-sorted-test start group=yes
-private static final List<String> b = [
-  // keep-sorted-test start
-  "x",
-  "x",
-  "y"
+  // keep-sorted-test start group=yes
+  private static final List<String> b = [
+    // keep-sorted-test start
+    "x",
+    "x",
+    "y"
+    // keep-sorted-test end
+    ];
+  private static final List<String> a = [
+    // keep-sorted-test start newline_separated=yes
+    "3",
+    "2",
+    "1"
+    // keep-sorted-test end
+    ];
   // keep-sorted-test end
-  ];
-private static final List<String> a = [
-  // keep-sorted-test start newline_separated=yes
-  "3",
-  "2",
-  "1"
-  // keep-sorted-test end
-  ];
-// keep-sorted-test end
 
 Nested keep-sorted without indentation
-// keep-sorted-test start group=yes newline_separated=yes
+  // keep-sorted-test start group=yes newline_separated=yes
+  
+  // def
+  // keep-sorted-test start
+  3
+  1
+  2
+  // keep-sorted-test end
+  
+  // abc
+  // keep-sorted-test start
+  b
+  c
+  a
+  // keep-sorted-test end
+  
+  // keep-sorted-test end
 
-// def
-// keep-sorted-test start
-3
-1
-2
-// keep-sorted-test end
+Sorting a switch statement with consecutive cases.
+  switch (foo) {
+  // keep-sorted-test start group_prefixes=case
+  case 2:
+    return 2;
+  case 6:
+    return 6;
+  case 4:
+    return 4;
+  case 3:
+  case 1:
+  case 5:
+    return 10
+  // keep-sorted-test end
 
-// abc
-// keep-sorted-test start
-b
-c
-a
-// keep-sorted-test end
-
-// keep-sorted-test end
+Sorting a switch statement with consecutive cases using nested keep-sorted block
+  switch (foo) {
+  // keep-sorted-test start
+  case 2:
+    return 2;
+  case 6:
+    return 6;
+  case 4:
+    return 4;
+  // keep-sorted-test start
+  case 3:
+  case 1:
+  case 5:
+  // keep-sorted-test end
+    return 10
+  // keep-sorted-test end

--- a/goldens/group.in
+++ b/goldens/group.in
@@ -158,6 +158,7 @@ Nested keep-sorted without indentation
   // keep-sorted-test end
 
 Sorting a switch statement with consecutive cases.
+Note: This doesn't actually work how I was hoping, but it does exercise an edge case.
   switch (foo) {
   // keep-sorted-test start group_prefixes=case
   case 2:

--- a/goldens/group.out
+++ b/goldens/group.out
@@ -161,15 +161,15 @@ Sorting a switch statement with consecutive cases.
   switch (foo) {
   // keep-sorted-test start group_prefixes=case
   case 2:
-    return 10
     return 2;
   case 6:
+    return 6;
+  case 4:
     return 4;
   case 3:
   case 1:
   case 5:
-    return 6;
-  case 4:
+    return 10
   // keep-sorted-test end
 
 Sorting a switch statement with consecutive cases using nested keep-sorted block

--- a/goldens/group.out
+++ b/goldens/group.out
@@ -1,24 +1,24 @@
 Group indented lines:
-public class Foo {
-  // keep-sorted-test start group=yes
-  private final Bar bar;
-  private final Baz baz =
-      new Baz();
-  private final Foo foo;
-  private final Qux qux;
-  // keep-sorted-test end
-}
+  public class Foo {
+    // keep-sorted-test start group=yes
+    private final Bar bar;
+    private final Baz baz =
+        new Baz();
+    private final Foo foo;
+    private final Qux qux;
+    // keep-sorted-test end
+  }
 
 Same thing but it's tabs:
-public class Foo {
-	// keep-sorted-test start group=yes
-	private final Bar bar;
-	private final Baz baz =
-			new Baz();
-	private final Foo foo;
-	private final Qux qux;
-	// keep-sorted-test end
-}
+  public class Foo {
+  	// keep-sorted-test start group=yes
+  	private final Bar bar;
+  	private final Baz baz =
+  			new Baz();
+  	private final Foo foo;
+  	private final Qux qux;
+  	// keep-sorted-test end
+  }
 
 Do not count indent from empty lines:
   // keep-sorted-test start
@@ -29,130 +29,162 @@ Do not count indent from empty lines:
   // keep-sorted-test end
 
 Multiple indentions:
-public class Foo {
-  // keep-sorted-test start group=yes
-  private final Bar bar;
-  private final Baz baz =
-      new
-          Baz();
-  private final Foo foo;
-  private final Qux qux;
-  // keep-sorted-test end
-}
+  public class Foo {
+    // keep-sorted-test start group=yes
+    private final Bar bar;
+    private final Baz baz =
+        new
+            Baz();
+    private final Foo foo;
+    private final Qux qux;
+    // keep-sorted-test end
+  }
 
 With sticky comments:
-public class Foo {
-  // keep-sorted-test start group=yes sticky_comments=yes
-  private final Bar bar;
-  // What a long line!
-  private final Baz baz =
-      new Baz();
-  private final Foo foo;
-  private final Qux qux;
-  // keep-sorted-test end
-}
+  public class Foo {
+    // keep-sorted-test start group=yes sticky_comments=yes
+    private final Bar bar;
+    // What a long line!
+    private final Baz baz =
+        new Baz();
+    private final Foo foo;
+    private final Qux qux;
+    // keep-sorted-test end
+  }
 
 Sorting doesn't take newline into account
-// keep-sorted-test start group=yes
-line
-  1
-line 2
-line
-  3
-line 4
-// keep-sorted-test end
+  // keep-sorted-test start group=yes
+  line
+    1
+  line 2
+  line
+    3
+  line 4
+  // keep-sorted-test end
 
 With list separator
-// keep-sorted-test start group=yes
-Bar bar,
-Baz
-    baz,
-Foo foo
-// keep-sorted-test end
+  // keep-sorted-test start group=yes
+  Bar bar,
+  Baz
+      baz,
+  Foo foo
+  // keep-sorted-test end
 
 Without whitespace on unbroken lines
-// keep-sorted-test start group=yes
-SomeLongEnumTypeNameWithLongValueNames
-    .A_SOME_LONG_ENUM_VALUE_THAT_REQUIRES_A_LINE_BREAK
-SomeLongEnumTypeNameWithLongValueNames.B_SHORT_VALUE
-SomeLongEnumTypeNameWithLongValueNames
-    .C_SOME_LONG_ENUM_VALUE_THAT_REQUIRES_A_LINE_BREAK
-SomeLongEnumTypeNameWithLongValueNames.D_SHORT_VALUE
-// keep-sorted-test end
+  // keep-sorted-test start group=yes
+  SomeLongEnumTypeNameWithLongValueNames
+      .A_SOME_LONG_ENUM_VALUE_THAT_REQUIRES_A_LINE_BREAK
+  SomeLongEnumTypeNameWithLongValueNames.B_SHORT_VALUE
+  SomeLongEnumTypeNameWithLongValueNames
+      .C_SOME_LONG_ENUM_VALUE_THAT_REQUIRES_A_LINE_BREAK
+  SomeLongEnumTypeNameWithLongValueNames.D_SHORT_VALUE
+  // keep-sorted-test end
 
 Without grouping:
-public class Foo {
-  // keep-sorted-test start group=no
-      new Baz();
-  private final Bar bar;
-  private final Baz baz =
-  private final Foo foo;
-  private final Qux qux;
-  // keep-sorted-test end
-}
+  public class Foo {
+    // keep-sorted-test start group=no
+        new Baz();
+    private final Bar bar;
+    private final Baz baz =
+    private final Foo foo;
+    private final Qux qux;
+    // keep-sorted-test end
+  }
 
 Indented markdown lists:
-<!-- keep-sorted-test start group=yes -->
-
- * Bar
- * Baz
-     * Philosophical conjecture
- * Foo
-     * Wise insight
-
-<!-- keep-sorted-test end -->
+  <!-- keep-sorted-test start group=yes -->
+  
+   * Bar
+   * Baz
+       * Philosophical conjecture
+   * Foo
+       * Wise insight
+  
+  <!-- keep-sorted-test end -->
 
 Nested keep-sorted
-// keep-sorted-test start group=yes
-private static final List<String> a = [
-  // keep-sorted-test start
-  "1",
-  "2",
-  "3"
+  // keep-sorted-test start group=yes
+  private static final List<String> a = [
+    // keep-sorted-test start
+    "1",
+    "2",
+    "3"
+    // keep-sorted-test end
+    ];
+  private static final List<String> b = [
+    // keep-sorted-test start
+    "x",
+    "y",
+    "z"
+    // keep-sorted-test end
+    ];
   // keep-sorted-test end
-  ];
-private static final List<String> b = [
-  // keep-sorted-test start
-  "x",
-  "y",
-  "z"
-  // keep-sorted-test end
-  ];
-// keep-sorted-test end
 
 Nested keep-sorted, nested blocks change their number of lines.
-// keep-sorted-test start group=yes
-private static final List<String> a = [
-  // keep-sorted-test start newline_separated=yes
-  "1",
+  // keep-sorted-test start group=yes
+  private static final List<String> a = [
+    // keep-sorted-test start newline_separated=yes
+    "1",
 
-  "2",
+    "2",
 
-  "3"
+    "3"
+    // keep-sorted-test end
+    ];
+  private static final List<String> b = [
+    // keep-sorted-test start
+    "x",
+    "y"
+    // keep-sorted-test end
+    ];
   // keep-sorted-test end
-  ];
-private static final List<String> b = [
-  // keep-sorted-test start
-  "x",
-  "y"
-  // keep-sorted-test end
-  ];
-// keep-sorted-test end
 
 Nested keep-sorted without indentation
-// keep-sorted-test start group=yes newline_separated=yes
-// def
-// keep-sorted-test start
-1
-2
-3
-// keep-sorted-test end
+  // keep-sorted-test start group=yes newline_separated=yes
+  // def
+  // keep-sorted-test start
+  1
+  2
+  3
+  // keep-sorted-test end
 
-// abc
-// keep-sorted-test start
-a
-b
-c
-// keep-sorted-test end
+  // abc
+  // keep-sorted-test start
+  a
+  b
+  c
+  // keep-sorted-test end
+  
+  // keep-sorted-test end
 
-// keep-sorted-test end
+Sorting a switch statement with consecutive cases.
+  switch (foo) {
+  // keep-sorted-test start group_prefixes=case
+  case 2:
+    return 10
+    return 2;
+  case 6:
+    return 4;
+  case 3:
+  case 1:
+  case 5:
+    return 6;
+  case 4:
+  // keep-sorted-test end
+
+Sorting a switch statement with consecutive cases using nested keep-sorted block
+  switch (foo) {
+  // keep-sorted-test start
+  // keep-sorted-test start
+  case 1:
+  case 3:
+  case 5:
+  // keep-sorted-test end
+    return 10
+  case 2:
+    return 2;
+  case 4:
+    return 4;
+  case 6:
+    return 6;
+  // keep-sorted-test end

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -236,12 +236,9 @@ func (b block) sorted() (sorted []string, alreadySorted bool) {
 		}
 	}
 
+	log.Printf("Groups for block at index %d are (options %v)", b.start, b.metadata.opts)
 	groups := groupLines(lines, b.metadata)
-	log.Printf("%d groups for block at index %d are (options %v)", len(groups), b.start, b.metadata.opts)
-	for _, lg := range groups {
-		log.Printf("%#v", lg)
-	}
-
+	log.Printf("%d groups", len(groups))
 	trimTrailingComma := handleTrailingComma(groups)
 
 	wasNewlineSeparated := true

--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -20,6 +20,8 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+
+	"github.com/rs/zerolog/log"
 )
 
 // lineGroup is a logical unit of source code. It's one or more lines combines
@@ -69,6 +71,11 @@ func groupLines(lines []string, metadata blockMetadata) []lineGroup {
 				numUnmatchedStartDirectives--
 			}
 		}
+
+		if metadata.opts.Group && initialIndent == nil {
+			initialIndent = &indents[i]
+			log.Printf("initialIndent: %d", *initialIndent)
+		}
 	}
 	// finish an outstanding lineGroup and reset our state to prepare for a new lineGroup.
 	finishGroup := func() {
@@ -76,6 +83,7 @@ func groupLines(lines []string, metadata blockMetadata) []lineGroup {
 		commentRange = indexRange{}
 		lineRange = indexRange{}
 		block = codeBlock{}
+		log.Printf("%#v", groups[len(groups)-1])
 	}
 	for i, l := range lines {
 		if metadata.opts.Block && !lineRange.empty() && block.expectsContinuation() {
@@ -99,9 +107,6 @@ func groupLines(lines []string, metadata blockMetadata) []lineGroup {
 		} else {
 			if !lineRange.empty() {
 				finishGroup()
-			}
-			if metadata.opts.Group && initialIndent == nil {
-				initialIndent = &indents[i]
 			}
 			appendLine(i, l)
 		}


### PR DESCRIPTION
1. When the first seen line is one of the `group_prefixes`.
2. When the first seen line is another keep-sorted directive.

Idempotency output before this change:

```
$ go test ./...
?       github.com/google/keep-sorted   [no test files]
?       github.com/google/keep-sorted/cmd       [no test files]
--- FAIL: TestGoldens (0.66s)
    --- FAIL: TestGoldens/group (0.00s)
        --- FAIL: TestGoldens/group/group (0.66s)
            golden_test.go:105: keep-sorted diff on keep-sorted output (should be idempotent) (-want +got)
                  (
                        """
                        ... // 180 identical lines
                          case 5:
                          // keep-sorted-test end
                -           return 10
                          case 2:
                -           return 2;
                          case 4:
                +         case 6:
                +           return 10
                +           return 2;
                            return 4;
                -         case 6:
                            return 6;
                          // keep-sorted-test end
                        """
                  )
FAIL
FAIL    github.com/google/keep-sorted/goldens   0.686s
ok      github.com/google/keep-sorted/keepsorted        (cached)
FAIL
```

Also, check the git history to see how group.out evolved.