### PR TITLE
fix: Print options correctly when their lists or sets need to be YAML lists.

### DIFF
--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -199,7 +199,7 @@ func formatValue(val reflect.Value) (string, error) {
 
 func formatList(vals []string) (string, error) {
 	var specialChars bool
-	if len(vals) > 0 && vals[0][0] == '[' {
+	if len(vals) > 0 && strings.HasPrefix(vals[0], "[") {
 		specialChars = true
 	} else {
 		for _, val := range vals {

--- a/keepsorted/options_parser.go
+++ b/keepsorted/options_parser.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 var (

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -182,7 +182,18 @@ func TestBlockOptions(t *testing.T) {
 				t.Errorf("parseBlockOptions(%q, %q) mismatch (-want +got):\n%s", tc.commentMarker, tc.in, diff)
 			}
 
-			_ = got.String() // Make sure this doesn't panic.
+			if tc.wantErr == "" {
+				t.Run("StringRoundtrip", func(t *testing.T) {
+					s := got.String()
+					got2, warns := parseBlockOptions(tc.commentMarker, s, tc.defaultOptions)
+					if err := errors.Join(warns...); err != nil {
+						t.Errorf("parseBlockOptions(%q, %q) = %v", tc.commentMarker, s, err)
+					}
+					if diff := cmp.Diff(got, got2, cmp.AllowUnexported(blockOptions{})); diff != "" {
+						t.Errorf("parseBlockOptions(%q, %q) mismatch (-want +got):\n%s", tc.commentMarker, s, diff)
+					}
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
Right now, options that need their lists or sets to be YAML lists aren't printing a roundtrippable string.