### PR TITLE
Add comment_order option to sort by line comment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,44 @@ This can also be combined with numerical sorting:
  ]
 ```
 
+#### Comment Sorting
+
+In some use cases, sorting by a comment identifier is preferable to sorting by value.
+By specifying `comment_order=yes`, the comment text for the line is prioritized when
+sorting.
+
+<table border="0">
+<tr>
+<td>
+
+```
+# keep-sorted start
+200.6.6.7     # Cluster B - Address 2
+200.6.7.8     # Cluster B - Address 1
+34.9.100.220  # Cluster A - Address 2
+35.18.1.22    # Cluster A - Address 3
+35.18.1.40    # Cluster A - Address 1
+# keep-sorted end
+```
+
+</td>
+<td>
+
+```diff
++# keep-sorted start comment_order=yes
+ 35.18.1.40    # Cluster A - Address 1
+ 34.9.100.220  # Cluster A - Address 2
+ 35.18.1.22    # Cluster A - Address 3
+ 200.6.7.8     # Cluster B - Address 1
+ 200.6.6.7     # Cluster B - Address 2
+ # keep-sorted end
+```
+
+</td>
+</tr>
+</table>
+
+
 ### Post-sorting options
 
 Post-sorting options are additional convenience features that make the resulting

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/rs/zerolog/log"
 )
@@ -425,6 +426,12 @@ func (b block) lessFn() func(a, b lineGroup) int {
 		}
 		if !b.metadata.opts.CaseSensitive {
 			l = strings.ToLower(l)
+		}
+		if b.metadata.opts.CommentOrder {
+			_, a, ok := strings.Cut(l, b.metadata.opts.commentMarker)
+			if ok {
+				l = strings.TrimLeftFunc(a, unicode.IsSpace)
+			}
 		}
 		return b.metadata.opts.maybeParseNumeric(l)
 	}, numericTokens.compare)

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -1169,6 +1169,30 @@ func TestLineSorting(t *testing.T) {
 			want:              []string{},
 			wantAlreadySorted: true,
 		},
+		{
+			name: "SortByComment",
+			opts: func() blockOptions {
+				opts := blockOptions{
+					CommentOrder: true,
+				}
+				opts.setCommentMarker("//")
+				return opts
+			}(),
+
+			in: []string{
+				"c // 1",
+				"22",
+				"a // 3",
+				"b // 2",
+			},
+
+			want: []string{
+				"c // 1",
+				"b // 2",
+				"22",
+				"a // 3",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			initZerolog(t)

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -90,6 +90,8 @@ type blockOptions struct {
 	PrefixOrder []string `key:"prefix_order"`
 	// IgnorePrefixes is a slice of prefixes that we do not consider when sorting lines.
 	IgnorePrefixes []string `key:"ignore_prefixes"`
+	// CommentOrder allows the user to sort lines based on their comment.
+	CommentOrder bool `key:"comment_order"`
 
 	////////////////////////////
 	//  Post-sorting options  //


### PR DESCRIPTION
keep-sorted is very popular with my team and its control comments are routinely added to multiline sequences, but the results aren't what I'd prefer in some cases such as in concrete Kubernetes manifests where our options to tag data like IP addresses with a meaningful identifier are limited to code comments.