### PR TITLE
fix: Continue to group nested keep-sorted blocks together if both group=yes and block=yes are set.

### DIFF
--- a/goldens/golden_test.go
+++ b/goldens/golden_test.go
@@ -62,48 +62,51 @@ func TestGoldens(t *testing.T) {
 	}
 
 	needsRegen := make(chan string, 2*len(tcs))
-	for _, tc := range tcs {
-		t.Run(tc, func(t *testing.T) {
-			t.Parallel()
-			inFile := filepath.Join(dir, tc+".in")
-			in, err := os.Open(inFile)
-			if err != nil {
-				t.Fatalf("Could not open .in file: %v", err)
-			}
-
-			wantOut, err := os.ReadFile(filepath.Join(dir, tc+".out"))
-			if err != nil {
-				t.Fatalf("Could not read .out file: %v", err)
-			}
-			wantErr, err := os.ReadFile(filepath.Join(dir, tc+".err"))
-			if err != nil {
-				if !errors.Is(err, os.ErrNotExist) {
-					t.Fatalf("Could not read .err file: %v", err)
+	// The outer t.Run doesn't return until all the parallel tests have completed.
+	t.Run("parallelTests", func(t *testing.T) {
+		for _, tc := range tcs {
+			t.Run(tc, func(t *testing.T) {
+				t.Parallel()
+				inFile := filepath.Join(dir, tc+".in")
+				in, err := os.Open(inFile)
+				if err != nil {
+					t.Fatalf("Could not open .in file: %v", err)
 				}
-			}
 
-			gotOut, gotErr, err := runKeepSorted(in)
-			if err != nil {
-				t.Errorf("Had trouble running keep-sorted: %v", err)
-			}
-			if diff := cmp.Diff(strings.Split(string(wantOut), "\n"), strings.Split(gotOut, "\n")); diff != "" {
-				t.Errorf("keep-sorted stdout diff (-want +got):\n%s", diff)
-				needsRegen <- inFile
-			}
-			if diff := cmp.Diff(strings.Split(string(wantErr), "\n"), strings.Split(gotErr, "\n")); diff != "" {
-				t.Errorf("keep-sorted stderr diff (-want +got):\n%s", diff)
-				needsRegen <- inFile
-			}
+				wantOut, err := os.ReadFile(filepath.Join(dir, tc+".out"))
+				if err != nil {
+					t.Fatalf("Could not read .out file: %v", err)
+				}
+				wantErr, err := os.ReadFile(filepath.Join(dir, tc+".err"))
+				if err != nil {
+					if !errors.Is(err, os.ErrNotExist) {
+						t.Fatalf("Could not read .err file: %v", err)
+					}
+				}
 
-			gotOut2, _, err := runKeepSorted(strings.NewReader(gotOut))
-			if err != nil {
-				t.Errorf("Had trouble running keep-sorted on keep-sorted output: %v", err)
-			}
-			if diff := cmp.Diff(gotOut, gotOut2); diff != "" {
-				t.Errorf("keep-sorted diff on keep-sorted output (should be idempotent) (-want +got)\n%s", diff)
-			}
-		})
-	}
+				gotOut, gotErr, err := runKeepSorted(in)
+				if err != nil {
+					t.Errorf("Had trouble running keep-sorted: %v", err)
+				}
+				if diff := cmp.Diff(strings.Split(string(wantOut), "\n"), strings.Split(gotOut, "\n")); diff != "" {
+					t.Errorf("keep-sorted stdout diff (-want +got):\n%s", diff)
+					needsRegen <- inFile
+				}
+				if diff := cmp.Diff(strings.Split(string(wantErr), "\n"), strings.Split(gotErr, "\n")); diff != "" {
+					t.Errorf("keep-sorted stderr diff (-want +got):\n%s", diff)
+					needsRegen <- inFile
+				}
+
+				gotOut2, _, err := runKeepSorted(strings.NewReader(gotOut))
+				if err != nil {
+					t.Errorf("Had trouble running keep-sorted on keep-sorted output: %v", err)
+				}
+				if diff := cmp.Diff(gotOut, gotOut2); diff != "" {
+					t.Errorf("keep-sorted diff on keep-sorted output (should be idempotent) (-want +got)\n%s", diff)
+				}
+			})
+		}
+	})
 
 	close(needsRegen)
 	files := make(map[string]bool)

--- a/goldens/group.in
+++ b/goldens/group.in
@@ -207,3 +207,20 @@ where the nested keep-sorted block shouldn't be the first element.
   case 1:
     return 1;
   // keep-sorted-test end
+
+The same, except block=yes is also set.
+  switch (foo) {
+  // keep-sorted-test start block=yes
+  case 5:
+    return 5;
+  // keep-sorted-test start block=yes
+  case 2:
+  case 6:
+  case 4:
+  // keep-sorted-test end
+    return 10;
+  case 3:
+    return 3;
+  case 1:
+    return 1;
+  // keep-sorted-test end

--- a/goldens/group.out
+++ b/goldens/group.out
@@ -207,3 +207,20 @@ where the nested keep-sorted block shouldn't be the first element.
   case 5:
     return 5;
   // keep-sorted-test end
+
+The same, except block=yes is also set.
+  switch (foo) {
+  // keep-sorted-test start block=yes
+  case 1:
+    return 1;
+  // keep-sorted-test start block=yes
+  case 2:
+  case 3:
+    return 3;
+  case 4:
+  case 5:
+    return 5;
+  case 6:
+  // keep-sorted-test end
+    return 10;
+  // keep-sorted-test end

--- a/goldens/group.out
+++ b/goldens/group.out
@@ -215,12 +215,12 @@ The same, except block=yes is also set.
     return 1;
   // keep-sorted-test start block=yes
   case 2:
-  case 3:
-    return 3;
   case 4:
-  case 5:
-    return 5;
   case 6:
   // keep-sorted-test end
     return 10;
+  case 3:
+    return 3;
+  case 5:
+    return 5;
   // keep-sorted-test end

--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -72,7 +72,8 @@ func groupLines(lines []string, metadata blockMetadata) []lineGroup {
 		lineRange.append(i)
 		if metadata.opts.Block {
 			block.append(l, metadata.opts)
-		} else if metadata.opts.Group {
+		}
+		if metadata.opts.Group {
 			countStartDirectives(l)
 		}
 
@@ -101,7 +102,7 @@ func groupLines(lines []string, metadata blockMetadata) []lineGroup {
 				finishGroup()
 			}
 
-			if !metadata.opts.Block && metadata.opts.Group && strings.Contains(l, metadata.startDirective) {
+			if metadata.opts.Group && strings.Contains(l, metadata.startDirective) {
 				// We don't need to check for end directives here because this makes
 				// numUnmatchedStartDirectives > 0, so we'll take the code path above through appendLine.
 				if lineRange.empty() {


### PR DESCRIPTION
See git history of this PR to see how group.out has changed.