### PR TITLE
fix: Ignore leading whitespace after applying ignore_prefixes.

### DIFF
--- a/goldens/ignore_prefixes.in
+++ b/goldens/ignore_prefixes.in
@@ -56,7 +56,7 @@ Combine with numerical:
   # keep-sorted-test end
 
 Prefixes with spaces:
-  # keep-sorted-test start ignore_prefixes=['* ', '* [']
+  # keep-sorted-test start ignore_prefixes=['*', '* [']
   * foo
   * bar
   * [baz](path/to/baz)

--- a/goldens/ignore_prefixes.out
+++ b/goldens/ignore_prefixes.out
@@ -58,6 +58,6 @@ Combine with numerical:
 Prefixes with spaces:
   # keep-sorted-test start ignore_prefixes=['*', '* [']
   * bar
-  * foo
   * [baz](path/to/baz)
+  * foo
   # keep-sorted-test end

--- a/goldens/ignore_prefixes.out
+++ b/goldens/ignore_prefixes.out
@@ -56,8 +56,8 @@ Combine with numerical:
   # keep-sorted-test end
 
 Prefixes with spaces:
-  # keep-sorted-test start ignore_prefixes=['* ', '* [']
+  # keep-sorted-test start ignore_prefixes=['*', '* [']
   * bar
-  * [baz](path/to/baz)
   * foo
+  * [baz](path/to/baz)
   # keep-sorted-test end

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -324,7 +324,7 @@ func (opts blockOptions) removeIgnorePrefix(s string) (string, bool) {
 	t := strings.TrimLeftFunc(s, unicode.IsSpace)
 	for _, p := range opts.IgnorePrefixes {
 		if strings.HasPrefix(t, p) {
-			return strings.Replace(s, p, "", 1), true
+			return strings.TrimLeftFunc(strings.Replace(s, p, "", 1), unicode.IsSpace), true
 		}
 	}
 	return "", false


### PR DESCRIPTION
See the history of this PR to see how ignore_prefixes.out has changed.

Fix https://github.com/google/keep-sorted/issues/54