### PR TITLE
fix: Do not automatically remove unmatched start/end directives when fixing.

### DIFF
--- a/keepsorted/keep_sorted.go
+++ b/keepsorted/keep_sorted.go
@@ -219,18 +219,6 @@ func replacement(start, end int, s string) Fix {
 	}
 }
 
-func automaticReplacement(start, end int, s string) Fix {
-	return Fix{
-		automatic: true,
-		Replacements: []Replacement{
-			{
-				Lines:      lineRange(start, end),
-				NewContent: s,
-			},
-		},
-	}
-}
-
 func lineRange(start, end int) LineRange {
 	return LineRange{
 		Start: start,

--- a/keepsorted/keep_sorted.go
+++ b/keepsorted/keep_sorted.go
@@ -27,6 +27,10 @@ const (
 	errorUnordered = "These lines are out of order."
 )
 
+func errorMissingDirective(dir string) string {
+	return fmt.Sprintf("This instruction doesn't have matching '%s' line", dir)
+}
+
 // Fixer runs the business logic of keep-sorted.
 type Fixer struct {
 	ID string
@@ -47,31 +51,35 @@ func New(id string, defaultOptions BlockOptions) *Fixer {
 	}
 }
 
-func (f *Fixer) errorMissingStart() string {
-	return fmt.Sprintf("This instruction doesn't have matching '%s' line", f.startDirective)
-}
-
-func (f *Fixer) errorMissingEnd() string {
-	return fmt.Sprintf("This instruction doesn't have matching '%s' line", f.endDirective)
-}
-
 // Fix all of the findings on contents to make keep-sorted happy.
 func (f *Fixer) Fix(filename, contents string, modifiedLines []LineRange) (fixed string, alreadyCorrect bool, warnings []*Finding) {
 	lines := strings.Split(contents, "\n")
-	fs := f.findings(filename, lines, modifiedLines)
-	if len(fs) == 0 {
+	findings := f.findings(filename, lines, modifiedLines)
+	if len(findings) == 0 {
 		return contents, true, nil
 	}
 
 	var s strings.Builder
 	startLine := 1
-	for _, f := range fs {
-		if len(f.Fixes) == 0 {
-			warnings = append(warnings, f)
+	for _, finding := range findings {
+		var fix *Fix
+		for _, f := range finding.Fixes {
+			if !f.automatic {
+				continue
+			}
+			if fix == nil {
+				fix = &f
+			} else {
+				panic(fmt.Errorf("multiple automatic fixes in finding: %v", finding))
+			}
+		}
+
+		if fix == nil {
+			warnings = append(warnings, finding)
 			continue
 		}
 
-		repl := f.Fixes[0].Replacements[0]
+		repl := fix.Replacements[0]
 		endLine := repl.Lines.Start
 
 		// -1 to convert line number to index number.
@@ -105,6 +113,7 @@ type Finding struct {
 	// Possible fixes that could be applied to resolve the problem.
 	// Each fix in this slice would independently fix the problem, they do not
 	// and should not all be applied.
+	// At most one of these Fixes may have Fix.automatic set to true.
 	Fixes []Fix `json:"fixes"`
 }
 
@@ -121,6 +130,9 @@ type Fix struct {
 	// The changes that should be made to the file to resolve the Finding.
 	// All of these changes need to be made.
 	Replacements []Replacement `json:"replacements"`
+
+	// Whether this fix will be automatically applied in Fixer.Fix.
+	automatic bool
 }
 
 // Replacement is a single substitution to apply to a file.
@@ -134,23 +146,29 @@ func (f *Fixer) findings(filename string, contents []string, modifiedLines []Lin
 	blocks, incompleteBlocks, warns := f.newBlocks(filename, contents, 1, includeModifiedLines(modifiedLines))
 
 	var fs []*Finding
+
 	fs = append(fs, warns...)
-	for _, b := range blocks {
-		if s, alreadySorted := b.sorted(); !alreadySorted {
-			fs = append(fs, finding(filename, b.start+1, b.end-1, errorUnordered, replacement(b.start+1, b.end-1, linesToString(s))))
-		}
-	}
+
 	for _, ib := range incompleteBlocks {
 		var msg string
 		switch ib.dir {
 		case startDirective:
-			msg = f.errorMissingEnd()
+			msg = errorMissingDirective(f.endDirective)
 		case endDirective:
-			msg = f.errorMissingStart()
+			msg = errorMissingDirective(f.startDirective)
 		default:
 			panic(fmt.Errorf("unknown directive type: %v", ib.dir))
 		}
 		fs = append(fs, finding(filename, ib.line, ib.line, msg, replacement(ib.line, ib.line, "")))
+	}
+
+	for _, b := range blocks {
+		if s, alreadySorted := b.sorted(); !alreadySorted {
+			repl := replacement(b.start+1, b.end-1, linesToString(s))
+			// Only try to automatically sort things if there are no incomplete blocks.
+			repl.automatic = len(incompleteBlocks) == 0
+			fs = append(fs, finding(filename, b.start+1, b.end-1, errorUnordered, repl))
+		}
 	}
 
 	slices.SortFunc(fs, func(a, b *Finding) int {
@@ -192,6 +210,18 @@ func finding(filename string, start, end int, msg string, fixes ...Fix) *Finding
 
 func replacement(start, end int, s string) Fix {
 	return Fix{
+		Replacements: []Replacement{
+			{
+				Lines:      lineRange(start, end),
+				NewContent: s,
+			},
+		},
+	}
+}
+
+func automaticReplacement(start, end int, s string) Fix {
+	return Fix{
+		automatic: true,
 		Replacements: []Replacement{
 			{
 				Lines:      lineRange(start, end),

--- a/keepsorted/keep_sorted.go
+++ b/keepsorted/keep_sorted.go
@@ -27,8 +27,8 @@ const (
 	errorUnordered = "These lines are out of order."
 )
 
-func errorMissingDirective(dir string) string {
-	return fmt.Sprintf("This instruction doesn't have matching '%s' line", dir)
+func errorMissingDirective(id, dir string) string {
+	return fmt.Sprintf("This instruction doesn't have matching '%s %s' line. %s will not attempt to sort anything until this is addressed.", id, dir, id)
 }
 
 // Fixer runs the business logic of keep-sorted.
@@ -153,9 +153,9 @@ func (f *Fixer) findings(filename string, contents []string, modifiedLines []Lin
 		var msg string
 		switch ib.dir {
 		case startDirective:
-			msg = errorMissingDirective(f.endDirective)
+			msg = errorMissingDirective(f.ID, "end")
 		case endDirective:
-			msg = errorMissingDirective(f.startDirective)
+			msg = errorMissingDirective(f.ID, "start")
 		default:
 			panic(fmt.Errorf("unknown directive type: %v", ib.dir))
 		}

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -180,7 +180,7 @@ foo
 			if gotAlreadyFixed != tc.wantAlreadyFixed {
 				t.Errorf("alreadyFixed diff: got %t want %t", gotAlreadyFixed, tc.wantAlreadyFixed)
 			}
-			if diff := cmp.Diff(tc.wantWarnings, messages(gotWarnings), cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantWarnings, messages(gotWarnings)); diff != "" {
 				t.Errorf("warnings diff (-want +got):\n%s", diff)
 			}
 		})
@@ -1548,9 +1548,9 @@ func TestLineGrouping(t *testing.T) {
 }
 
 func messages(fs []*Finding) []string {
-	ret := make([]string, len(fs))
-	for i, f := range fs {
-		ret[i] = f.Message
+	var ret []string
+	for _, f := range fs {
+		ret = append(ret, f.Message)
 	}
 	return ret
 }

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -1554,3 +1554,9 @@ func messages(fs []*Finding) []string {
 	}
 	return ret
 }
+
+func automaticReplacement(start, end int, s string) Fix {
+	repl := replacement(start, end, s)
+	repl.automatic = true
+	return repl
+}

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -121,7 +121,7 @@ func TestFix(t *testing.T) {
 1
 3
 // keep-sorted-test end`,
-			wantWarnings: []string{errorMissingDirective("keep-sorted-test end"), errorUnordered},
+			wantWarnings: []string{errorMissingDirective("keep-sorted-test", "end"), errorUnordered},
 		},
 		{
 			name: "UnmatchedEnd",
@@ -141,7 +141,7 @@ func TestFix(t *testing.T) {
 3
 // keep-sorted-test end
 // keep-sorted-test end`,
-			wantWarnings: []string{errorUnordered, errorMissingDirective("keep-sorted-test start")},
+			wantWarnings: []string{errorUnordered, errorMissingDirective("keep-sorted-test", "start")},
 		},
 		{
 			name: "MultipleFixes",
@@ -241,7 +241,7 @@ func TestFindings(t *testing.T) {
 			in: `
 // keep-sorted-test start`,
 
-			want: []*Finding{finding(filename, 2, 2, errorMissingDirective("keep-sorted-test end"), replacement(2, 2, ""))},
+			want: []*Finding{finding(filename, 2, 2, errorMissingDirective("keep-sorted-test", "end"), replacement(2, 2, ""))},
 		},
 		{
 			name: "MismatchedEnd",
@@ -249,7 +249,7 @@ func TestFindings(t *testing.T) {
 			in: `
 // keep-sorted-test end`,
 
-			want: []*Finding{finding(filename, 2, 2, errorMissingDirective("keep-sorted-test start"), replacement(2, 2, ""))},
+			want: []*Finding{finding(filename, 2, 2, errorMissingDirective("keep-sorted-test", "start"), replacement(2, 2, ""))},
 		},
 		{
 			name: "MultipleFindings",
@@ -270,8 +270,8 @@ baz
 `,
 
 			want: []*Finding{
-				finding(filename, 2, 2, errorMissingDirective("keep-sorted-test start"), replacement(2, 2, "")),
-				finding(filename, 3, 3, errorMissingDirective("keep-sorted-test end"), replacement(3, 3, "")),
+				finding(filename, 2, 2, errorMissingDirective("keep-sorted-test", "start"), replacement(2, 2, "")),
+				finding(filename, 3, 3, errorMissingDirective("keep-sorted-test", "end"), replacement(3, 3, "")),
 				finding(filename, 5, 7, errorUnordered, replacement(5, 7, "1\n2\n3\n")),
 				finding(filename, 10, 12, errorUnordered, replacement(10, 12, "bar\nbaz\nfoo\n")),
 			},

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -54,6 +54,7 @@ func TestFix(t *testing.T) {
 
 		want             string
 		wantAlreadyFixed bool
+		wantWarnings     []string
 	}{
 		{
 			name: "Empty",
@@ -108,43 +109,44 @@ func TestFix(t *testing.T) {
 			in: `
 // keep-sorted-test start
 // keep-sorted-test start
-1
 2
+1
 3
 // keep-sorted-test end`,
 
 			want: `
 // keep-sorted-test start
-1
+// keep-sorted-test start
 2
+1
 3
 // keep-sorted-test end`,
+			wantWarnings: []string{errorMissingDirective("keep-sorted-test end"), errorUnordered},
 		},
 		{
 			name: "UnmatchedEnd",
 
 			in: `
 // keep-sorted-test start
-1
 2
+1
 3
 // keep-sorted-test end
 // keep-sorted-test end`,
 
 			want: `
 // keep-sorted-test start
-1
 2
+1
 3
 // keep-sorted-test end
-`,
+// keep-sorted-test end`,
+			wantWarnings: []string{errorUnordered, errorMissingDirective("keep-sorted-test start")},
 		},
 		{
 			name: "MultipleFixes",
 
 			in: `
-// keep-sorted-test end
-// keep-sorted-test start
 // keep-sorted-test start
 2
 1
@@ -157,7 +159,6 @@ baz
 // keep-sorted-test end`,
 
 			want: `
-
 // keep-sorted-test start
 1
 2
@@ -179,8 +180,8 @@ foo
 			if gotAlreadyFixed != tc.wantAlreadyFixed {
 				t.Errorf("alreadyFixed diff: got %t want %t", gotAlreadyFixed, tc.wantAlreadyFixed)
 			}
-			if len(gotWarnings) != 0 {
-				t.Errorf("Fix returned warnings, expected none:\n%v", gotWarnings)
+			if diff := cmp.Diff(tc.wantWarnings, messages(gotWarnings), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("warnings diff (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -218,7 +219,7 @@ func TestFindings(t *testing.T) {
 3
 // keep-sorted-test end`,
 
-			want: []*Finding{finding(filename, 3, 5, errorUnordered, replacement(3, 5, "1\n2\n3\n"))},
+			want: []*Finding{finding(filename, 3, 5, errorUnordered, automaticReplacement(3, 5, "1\n2\n3\n"))},
 		},
 		{
 			name: "SkipLines",
@@ -232,7 +233,7 @@ func TestFindings(t *testing.T) {
 1
 // keep-sorted-test end`,
 
-			want: []*Finding{finding(filename, 5, 7, errorUnordered, replacement(5, 7, "1\n2\n3\n"))},
+			want: []*Finding{finding(filename, 5, 7, errorUnordered, automaticReplacement(5, 7, "1\n2\n3\n"))},
 		},
 		{
 			name: "MismatchedStart",
@@ -240,7 +241,7 @@ func TestFindings(t *testing.T) {
 			in: `
 // keep-sorted-test start`,
 
-			want: []*Finding{finding(filename, 2, 2, "This instruction doesn't have matching 'keep-sorted-test end' line", replacement(2, 2, ""))},
+			want: []*Finding{finding(filename, 2, 2, errorMissingDirective("keep-sorted-test end"), replacement(2, 2, ""))},
 		},
 		{
 			name: "MismatchedEnd",
@@ -248,7 +249,7 @@ func TestFindings(t *testing.T) {
 			in: `
 // keep-sorted-test end`,
 
-			want: []*Finding{finding(filename, 2, 2, "This instruction doesn't have matching 'keep-sorted-test start' line", replacement(2, 2, ""))},
+			want: []*Finding{finding(filename, 2, 2, errorMissingDirective("keep-sorted-test start"), replacement(2, 2, ""))},
 		},
 		{
 			name: "MultipleFindings",
@@ -269,8 +270,8 @@ baz
 `,
 
 			want: []*Finding{
-				finding(filename, 2, 2, "This instruction doesn't have matching 'keep-sorted-test start' line", replacement(2, 2, "")),
-				finding(filename, 3, 3, "This instruction doesn't have matching 'keep-sorted-test end' line", replacement(3, 3, "")),
+				finding(filename, 2, 2, errorMissingDirective("keep-sorted-test start"), replacement(2, 2, "")),
+				finding(filename, 3, 3, errorMissingDirective("keep-sorted-test end"), replacement(3, 3, "")),
 				finding(filename, 5, 7, errorUnordered, replacement(5, 7, "1\n2\n3\n")),
 				finding(filename, 10, 12, errorUnordered, replacement(10, 12, "bar\nbaz\nfoo\n")),
 			},
@@ -291,7 +292,7 @@ baz
 // keep-sorted-test end`,
 			modifiedLines: []int{3},
 
-			want: []*Finding{finding(filename, 3, 5, errorUnordered, replacement(3, 5, "1\n2\n3\n"))},
+			want: []*Finding{finding(filename, 3, 5, errorUnordered, automaticReplacement(3, 5, "1\n2\n3\n"))},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -303,7 +304,7 @@ baz
 				}
 			}
 			got := New("keep-sorted-test", BlockOptions{}).findings(filename, strings.Split(tc.in, "\n"), mod)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(Fix{})); diff != "" {
 				t.Errorf("Findings diff (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Still raise them in a lint warning, though.

Also, having an unmatched start/end directive likely means that the blocks we _do_ have are just straight up wrong. Stop trying to sort them automatically.

Fixes #50