### PR TITLE
fix: Return a non-zero error code if there are any warnings during fix.

### DIFF
--- a/goldens/by_regex.err
+++ b/goldens/by_regex.err
@@ -1,2 +1,3 @@
 WRN while parsing option "by_regex": error parsing regexp: missing argument to repetition operator: `*` line=85
 WRN by_regex cannot be used with ignore_prefixes (consider adding a non-capturing group to the start of your regex instead of ignore_prefixes: "(?:foo|bar)") line=92
+exit status 1

--- a/goldens/generate-goldens.sh
+++ b/goldens/generate-goldens.sh
@@ -25,7 +25,8 @@ for i in "$@"; do
   out="${i%%in}out"
   err="${i%%in}err"
 
-  go run "${git_dir}" --id=keep-sorted-test --omit-timestamps - <"${i}" >"${out}" 2>"${err}"
+  go run "${git_dir}" --id=keep-sorted-test --omit-timestamps - <"${i}" >"${out}" 2>"${err}" \
+    || true  # Ignore any non-zero exit codes.
   if (( $(wc -l < "${err}") == 0 )); then
     rm "${err}"
   fi

--- a/goldens/simple.err
+++ b/goldens/simple.err
@@ -1,3 +1,4 @@
 WRN skip_lines has invalid value: -1 line=105
 WRN unrecognized option "foo" line=105
 WRN while parsing option "ignore_prefixes": content appears to be an unterminated YAML list: "[abc, foo" line=112
+exit status 1


### PR DESCRIPTION
Also, report warnings even if the file is already "fixed". This seems like another bug that was lurking.

This change required less work than I was expecting. `go run` helpfully prints `error status %d` to stderr for us.

Fixes #77