### PR TITLE
feat: Change newline_separated support multiple newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,47 @@ Pineapples
 </tr>
 </table>
 
+Set newline_separated=yes for a single blank line, or
+newline_separated=N to separate items with N blank lines.
+
+<table border="0">
+<tr>
+<td>
+
+```
+# keep-sorted start
+Apples
+Bananas
+Oranges
+Pineapples
+# keep-sorted end
+
+
+
+```
+
+</td>
+<td>
+
+```diff
++# keep-sorted start newline_separated=2
+ Apples
+ 
+ 
+ Bananas
+ 
+ 
+ Oranges
+ 
+ 
+ Pineapples
+ # keep-sorted end
+```
+
+</td>
+</tr>
+</table>
+
 ### Syntax
 
 If you find yourself wanting to include special characters (spaces, commas, left

--- a/goldens/block.in
+++ b/goldens/block.in
@@ -138,6 +138,24 @@ some_build_rule(
 )
 // keep-sorted-test end
 
+// BUILD rule style with newlines=2
+// keep-sorted-test start block=yes newline_separated=2
+some_build_rule(
+    name = "def",
+    src = "some-source",
+)
+
+some_build_rule(
+    name = "xyz",
+    src = "another-source",
+)
+
+some_build_rule(
+    name = "abc",
+    src = "one-more-source",
+)
+// keep-sorted-test end
+
 // Nix multi line string
 // keep-sorted-test start block=yes newline_separated=yes
 foo = throw ''

--- a/goldens/block.out
+++ b/goldens/block.out
@@ -138,6 +138,26 @@ some_build_rule(
 )
 // keep-sorted-test end
 
+// BUILD rule style with newlines=2
+// keep-sorted-test start block=yes newline_separated=2
+some_build_rule(
+    name = "abc",
+    src = "one-more-source",
+)
+
+
+some_build_rule(
+    name = "def",
+    src = "some-source",
+)
+
+
+some_build_rule(
+    name = "xyz",
+    src = "another-source",
+)
+// keep-sorted-test end
+
 // Nix multi line string
 // keep-sorted-test start block=yes newline_separated=yes
 bar = ''

--- a/goldens/by_regex.err
+++ b/goldens/by_regex.err
@@ -1,3 +1,3 @@
-WRN while parsing option "by_regex": error parsing regexp: missing argument to repetition operator: `*` line=85
-WRN by_regex cannot be used with ignore_prefixes (consider adding a non-capturing group to the start of your regex instead of ignore_prefixes: "(?:foo|bar)") line=92
+WRN while parsing option "by_regex": error parsing regexp: missing argument to repetition operator: `*` line=99
+WRN by_regex cannot be used with ignore_prefixes (consider adding a non-capturing group to the start of your regex instead of ignore_prefixes: "(?:foo|bar)") line=106
 exit status 1

--- a/goldens/by_regex.in
+++ b/goldens/by_regex.in
@@ -71,6 +71,20 @@ Multiline blocks
   }
   keep-sorted-test end
 
+Multiline blocks with newlines=2
+  keep-sorted-test start block=yes newline_separated=2 by_regex=(\w+)\(\)\s+{
+  bool func2() {
+    return true;
+  }
+  int func1() {
+    return 1;
+  }
+  List<SomeReallyLongTypeParameterThatWouldForceTheFunctionNameOntoTheNextLine>
+      func0() {
+    return List.of(whatever);
+  }
+  keep-sorted-test end
+
 Regex doesn't match every line
   keep-sorted-test start by_regex=\d+
   3

--- a/goldens/by_regex.out
+++ b/goldens/by_regex.out
@@ -73,6 +73,24 @@ Multiline blocks
   }
   keep-sorted-test end
 
+Multiline blocks with newlines=2
+  keep-sorted-test start block=yes newline_separated=2 by_regex=(\w+)\(\)\s+{
+  List<SomeReallyLongTypeParameterThatWouldForceTheFunctionNameOntoTheNextLine>
+      func0() {
+    return List.of(whatever);
+  }
+
+
+  int func1() {
+    return 1;
+  }
+
+
+  bool func2() {
+    return true;
+  }
+  keep-sorted-test end
+
 Regex doesn't match every line
   keep-sorted-test start by_regex=\d+
   1

--- a/goldens/group.in
+++ b/goldens/group.in
@@ -138,8 +138,46 @@ Nested keep-sorted, nested blocks change their number of lines.
     ];
   // keep-sorted-test end
 
+Nested keep-sorted, nested blocks with newlines=2.
+  // keep-sorted-test start group=yes
+  private static final List<String> b = [
+    // keep-sorted-test start
+    "x",
+    "x",
+    "y"
+    // keep-sorted-test end
+    ];
+  private static final List<String> a = [
+    // keep-sorted-test start newline_separated=2
+    "3",
+    "2",
+    "1"
+    // keep-sorted-test end
+    ];
+  // keep-sorted-test end
+
+
 Nested keep-sorted without indentation
   // keep-sorted-test start group=yes newline_separated=yes
+  
+  // def
+  // keep-sorted-test start
+  3
+  1
+  2
+  // keep-sorted-test end
+  
+  // abc
+  // keep-sorted-test start
+  b
+  c
+  a
+  // keep-sorted-test end
+  
+  // keep-sorted-test end
+
+Nested keep-sorted without indentation, with newlines=3:
+  // keep-sorted-test start group=yes newline_separated=3
   
   // def
   // keep-sorted-test start

--- a/goldens/group.out
+++ b/goldens/group.out
@@ -139,6 +139,28 @@ Nested keep-sorted, nested blocks change their number of lines.
     ];
   // keep-sorted-test end
 
+Nested keep-sorted, nested blocks with newlines=2.
+  // keep-sorted-test start group=yes
+  private static final List<String> a = [
+    // keep-sorted-test start newline_separated=2
+    "1",
+
+
+    "2",
+
+
+    "3"
+    // keep-sorted-test end
+    ];
+  private static final List<String> b = [
+    // keep-sorted-test start
+    "x",
+    "y"
+    // keep-sorted-test end
+    ];
+  // keep-sorted-test end
+
+
 Nested keep-sorted without indentation
   // keep-sorted-test start group=yes newline_separated=yes
   // def
@@ -147,6 +169,26 @@ Nested keep-sorted without indentation
   2
   3
   // keep-sorted-test end
+
+  // abc
+  // keep-sorted-test start
+  a
+  b
+  c
+  // keep-sorted-test end
+  
+  // keep-sorted-test end
+
+Nested keep-sorted without indentation, with newlines=3:
+  // keep-sorted-test start group=yes newline_separated=3
+  // def
+  // keep-sorted-test start
+  1
+  2
+  3
+  // keep-sorted-test end
+
+
 
   // abc
   // keep-sorted-test start

--- a/goldens/simple.err
+++ b/goldens/simple.err
@@ -1,4 +1,4 @@
-WRN skip_lines has invalid value: -1 line=105
-WRN unrecognized option "foo" line=105
-WRN while parsing option "ignore_prefixes": content appears to be an unterminated YAML list: "[abc, foo" line=112
+WRN skip_lines has invalid value: -1 line=113
+WRN unrecognized option "foo" line=113
+WRN while parsing option "ignore_prefixes": content appears to be an unterminated YAML list: "[abc, foo" line=120
 exit status 1

--- a/goldens/simple.in
+++ b/goldens/simple.in
@@ -101,6 +101,14 @@ A
 B
 // keep-sorted-test end
 
+// keep-sorted-test start newline_separated=2
+C
+
+A
+
+B
+// keep-sorted-test end
+
 Invalid option
   keep-sorted-test start group=yes skip_lines=-1 foo=bar
   2

--- a/goldens/simple.out
+++ b/goldens/simple.out
@@ -100,6 +100,16 @@ B
 C
 // keep-sorted-test end
 
+// keep-sorted-test start newline_separated=2
+A
+
+
+B
+
+
+C
+// keep-sorted-test end
+
 Invalid option
   keep-sorted-test start group=yes skip_lines=-1 foo=bar
   1

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -239,15 +239,15 @@ func (b block) sorted() (sorted []string, alreadySorted bool) {
 	log.Printf("Previous %d groups were for block at index %d are (options %v)", len(groups), b.start, b.metadata.opts)
 	trimTrailingComma := handleTrailingComma(groups)
 
+	numNewlines := int(b.metadata.opts.NewlineSeparated)
 	wasNewlineSeparated := true
-	if b.metadata.opts.NewlineSeparated {
-		wasNewlineSeparated = isNewlineSeparated(groups)
+	if b.metadata.opts.NewlineSeparated > 0 {
+		wasNewlineSeparated = isNewlineSeparated(groups, numNewlines)
 		var withoutNewlines []lineGroup
 		for _, lg := range groups {
-			if isNewline(lg) {
-				continue
+			if !isAllEmpty(lg) {
+				withoutNewlines = append(withoutNewlines, lg)
 			}
-			withoutNewlines = append(withoutNewlines, lg)
 		}
 		groups = withoutNewlines
 	}
@@ -278,9 +278,9 @@ func (b block) sorted() (sorted []string, alreadySorted bool) {
 
 	trimTrailingComma(groups)
 
-	if b.metadata.opts.NewlineSeparated {
+	if b.metadata.opts.NewlineSeparated > 0 {
 		var separated []lineGroup
-		newline := lineGroup{lines: []string{""}}
+		newline := lineGroup{lines: make([]string, numNewlines)}
 		for _, lg := range groups {
 			if separated != nil {
 				separated = append(separated, newline)
@@ -297,36 +297,65 @@ func (b block) sorted() (sorted []string, alreadySorted bool) {
 	return l, false
 }
 
-// isNewlineSeparated determines if the given lineGroups are already NewlineSeparated.
+// isNewlineSeparated determines if the given lineGroups are already NewlineSeparated,
+// and are separated by groups containing exactly numNewlines empty lines.
 //
 // e.g.
 // non-empty group
-// newline group
+// newline group (repeated numNewlines times)
 // non-empty group
-// newline group
+// newline group (repeated numNewlines times)
 // .
 // .
 // .
 // non-empty group
-func isNewlineSeparated(gs []lineGroup) bool {
+func isNewlineSeparated(gs []lineGroup, numNewlines int) bool {
 	if len(gs) == 0 {
 		return true
 	}
-	// There should be an odd number of groups.
-	if len(gs)%2 != 1 {
+	if isAllEmpty(gs[len(gs)-1]) {
 		return false
 	}
-	for i := 0; i < (len(gs)-1)/2; i++ {
-		if isNewline(gs[2*i]) || !isNewline(gs[2*i+1]) {
+
+	i := 0
+	for i < len(gs) {
+		// Expect a data group (a group with at least one non-empty line or a comment)
+		if isAllEmpty(gs[i]) {
+			return false // Expected data group, found an empty group without comments
+		}
+		i++
+
+		// If this is the last group, we are done.
+		if i == len(gs) {
+			break
+		}
+
+		// Expect a separator of numNewlines empty lines.
+		emptyLinesCount := 0
+		// Sum up consecutive empty line groups
+		for i < len(gs) && isAllEmpty(gs[i]) {
+			emptyLinesCount += len(gs[i].lines)
+			i++
+		}
+
+		if emptyLinesCount != numNewlines {
+			return false // Incorrect number of newlines in the separator
+		}
+	}
+
+	return true
+}
+
+func isAllEmpty(lg lineGroup) bool {
+	if len(lg.comment) > 0 {
+		return false
+	}
+	for _, line := range lg.lines {
+		if strings.TrimSpace(line) != "" {
 			return false
 		}
 	}
-	return !isNewline(gs[len(gs)-1])
-}
-
-// isNewline determines if lg is just an empty line.
-func isNewline(lg lineGroup) bool {
-	return len(lg.comment) == 0 && len(lg.lines) == 1 && strings.TrimSpace(lg.lines[0]) == ""
+	return true
 }
 
 // handleTrailingComma handles the special case that all lines of a sorted segment are terminated

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -814,7 +814,7 @@ func TestLineSorting(t *testing.T) {
 			name: "AlreadySorted_NewlineSeparated",
 
 			opts: blockOptions{
-				NewlineSeparated: true,
+				NewlineSeparated: 1,
 			},
 			in: []string{
 				"Bar",
@@ -837,7 +837,7 @@ func TestLineSorting(t *testing.T) {
 			name: "AlreadySorted_ExceptForNewlineSorted",
 
 			opts: blockOptions{
-				NewlineSeparated: true,
+				NewlineSeparated: 1,
 			},
 			in: []string{
 				"Bar",
@@ -1142,7 +1142,7 @@ func TestLineSorting(t *testing.T) {
 			name: "NewlineSeparated",
 
 			opts: blockOptions{
-				NewlineSeparated: true,
+				NewlineSeparated: 1,
 			},
 			in: []string{
 				"B",
@@ -1163,11 +1163,105 @@ func TestLineSorting(t *testing.T) {
 			name: "NewlineSeparated_Empty",
 
 			opts: blockOptions{
-				NewlineSeparated: true,
+				NewlineSeparated: 1,
 			},
 			in: []string{},
 
 			want:              []string{},
+			wantAlreadySorted: true,
+		},
+		{
+			name: "NewlineSeparated_Count=1",
+
+			opts: blockOptions{
+				NewlineSeparated: 1,
+			},
+			in: []string{
+				"C",
+				"A",
+				"B",
+			},
+
+			want: []string{
+				"A",
+				"",
+				"B",
+				"",
+				"C",
+			},
+			wantAlreadySorted: false,
+		},
+		{
+			name: "NewlineSeparated_Count=2",
+
+			opts: blockOptions{
+				NewlineSeparated: 2,
+			},
+			in: []string{
+				"C",
+				"A",
+				"B",
+			},
+
+			want: []string{
+				"A",
+				"",
+				"",
+				"B",
+				"",
+				"",
+				"C",
+			},
+			wantAlreadySorted: false,
+		},
+		{
+			name: "NewlineSeparated_AlreadySorted_Count=1",
+
+			opts: blockOptions{
+				NewlineSeparated: 1,
+			},
+			in: []string{
+				"A",
+				"",
+				"B",
+				"",
+				"C",
+			},
+
+			want: []string{
+				"A",
+				"",
+				"B",
+				"",
+				"C",
+			},
+			wantAlreadySorted: true,
+		},
+		{
+			name: "NewlineSeparated_AlreadySorted_Count=2",
+
+			opts: blockOptions{
+				NewlineSeparated: 2,
+			},
+			in: []string{
+				"A",
+				"",
+				"",
+				"B",
+				"",
+				"",
+				"C",
+			},
+
+			want: []string{
+				"A",
+				"",
+				"",
+				"B",
+				"",
+				"",
+				"C",
+			},
 			wantAlreadySorted: true,
 		},
 	} {

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -273,7 +273,7 @@ func validate(opts *blockOptions) (warnings []error) {
 	}
 
 	if opts.NewlineSeparated < 0 {
-		warns = append(warns, fmt.Errorf("newline_separated has invalid value: %v", opts.SkipLines))
+		warns = append(warns, fmt.Errorf("newline_separated has invalid value: %v", opts.NewlineSeparated))
 		opts.NewlineSeparated = 0
 	}
 

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -30,6 +30,10 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
+// IntOrBool can be unmarshaled from a boolean or an integer value.
+// true is unmarshaled as 1, false as 0.
+type IntOrBool int
+
 type BlockOptions struct {
 	opts blockOptions
 }
@@ -99,7 +103,11 @@ type blockOptions struct {
 	////////////////////////////
 
 	// NewlineSeparated indicates that the groups should be separated with newlines.
-	NewlineSeparated bool `key:"newline_separated"`
+	// User can specify either an integer, or a boolean (to be backward compatible).
+	// 'no' or '0', it means no newlines should be added;
+	// 'yes' or '1', it means one newline should be added;
+	// Any other positive integer specifies the number of newlines to separate the groups.
+	NewlineSeparated IntOrBool `key:"newline_separated"`
 	// RemoveDuplicates determines whether we drop lines that are an exact duplicate.
 	RemoveDuplicates bool `key:"remove_duplicates"`
 
@@ -192,6 +200,8 @@ func formatValue(val reflect.Value) (string, error) {
 		return formatList(val.Interface().([]string))
 	case reflect.TypeFor[map[string]bool]():
 		return formatList(slices.Sorted(maps.Keys(val.Interface().(map[string]bool))))
+	case reflect.TypeFor[IntOrBool]():
+		return strconv.Itoa(int(val.Int())), nil
 	case reflect.TypeFor[int]():
 		return strconv.Itoa(int(val.Int())), nil
 	case reflect.TypeFor[[]*regexp.Regexp]():
@@ -260,6 +270,11 @@ func validate(opts *blockOptions) (warnings []error) {
 	if opts.SkipLines < 0 {
 		warns = append(warns, fmt.Errorf("skip_lines has invalid value: %v", opts.SkipLines))
 		opts.SkipLines = 0
+	}
+
+	if opts.NewlineSeparated < 0 {
+		warns = append(warns, fmt.Errorf("newline_separated has invalid value: %v", opts.SkipLines))
+		opts.NewlineSeparated = 0
 	}
 
 	if opts.GroupPrefixes != nil && !opts.Group {

--- a/keepsorted/options_parser.go
+++ b/keepsorted/options_parser.go
@@ -53,6 +53,9 @@ func (p *parser) popValue(typ reflect.Type) (reflect.Value, error) {
 	case reflect.TypeFor[bool]():
 		val, err := p.popBool()
 		return reflect.ValueOf(val), err
+	case reflect.TypeFor[IntOrBool]():
+		val, err := p.popIntOrBool()
+		return reflect.ValueOf(val), err
 	case reflect.TypeFor[int]():
 		val, err := p.popInt()
 		return reflect.ValueOf(val), err
@@ -107,6 +110,23 @@ func (p *parser) popInt() (int, error) {
 		return 0, err
 	}
 	return i, nil
+}
+
+func (p *parser) popIntOrBool() (IntOrBool, error) {
+	val, rest, _ := strings.Cut(p.line, " ")
+	p.line = rest
+	i, err := strconv.Atoi(val)
+	if err != nil {
+		b, ok := boolValues[val]
+		if ok {
+			if b {
+				return 1, nil
+			}
+			return 0, nil
+		}
+		return 0, err
+	}
+	return IntOrBool(i), nil
 }
 
 func (p *parser) popList() ([]string, error) {

--- a/keepsorted/options_parser_test.go
+++ b/keepsorted/options_parser_test.go
@@ -225,22 +225,23 @@ func TestPopValue(t *testing.T) {
 			want:          []*regexp.Regexp{regexp.MustCompile(".*"), regexp.MustCompile("abcd"), regexp.MustCompile("(?:efgh)ijkl")},
 		},
 		{
-			name: "Newlines",
+			name: "IntOrBool_Int",
 
 			input: "5",
 			want:  IntOrBool(5),
 		},
 		{
-			name:  "Newlines_BoolTrue",
+			name:  "IntOrBool_True",
 			input: "yes",
 			want:  IntOrBool(1),
 		},
 		{
-			name:  "Newlines_BoolFalse",
+			name:  "IntOrBool_False",
 			input: "no",
 			want:  IntOrBool(0),
-		},		{
-			name: "Newlines_Invalid",
+		},
+		{
+			name: "IntOrBool_Invalid",
 
 			input:   "foo",
 			want:    IntOrBool(0),

--- a/keepsorted/options_parser_test.go
+++ b/keepsorted/options_parser_test.go
@@ -224,6 +224,28 @@ func TestPopValue(t *testing.T) {
 			allowYAMLList: true,
 			want:          []*regexp.Regexp{regexp.MustCompile(".*"), regexp.MustCompile("abcd"), regexp.MustCompile("(?:efgh)ijkl")},
 		},
+		{
+			name: "Newlines",
+
+			input: "5",
+			want:  IntOrBool(5),
+		},
+		{
+			name:  "Newlines_BoolTrue",
+			input: "yes",
+			want:  IntOrBool(1),
+		},
+		{
+			name:  "Newlines_BoolFalse",
+			input: "no",
+			want:  IntOrBool(0),
+		},		{
+			name: "Newlines_Invalid",
+
+			input:   "foo",
+			want:    IntOrBool(0),
+			wantErr: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			suffix := "trailing content..."

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -82,6 +82,18 @@ func TestBlockOptions(t *testing.T) {
 			want: blockOptions{NewlineSeparated: 1},
 		},
 		{
+			name: "NewlineSeparated_Int",
+			in:   "newline_separated=10",
+
+			want: blockOptions{NewlineSeparated: 10},
+		},
+		{
+			name: "NewlineSeparated_Invalid",
+			in:   "newline_separated=-1",
+
+			wantErr: "newline_separated has invalid value: -1",
+		},
+		{
 			name: "ErrorSkipLinesIsNegative",
 			in:   "skip_lines=-1",
 

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -76,6 +76,12 @@ func TestBlockOptions(t *testing.T) {
 			want: blockOptions{SkipLines: 10},
 		},
 		{
+			name: "NewlineSeparated_Bool",
+			in:   "newline_separated=yes",
+
+			want: blockOptions{NewlineSeparated: 1},
+		},
+		{
 			name: "ErrorSkipLinesIsNegative",
 			in:   "skip_lines=-1",
 


### PR DESCRIPTION
1. Change the option newline_separated to a new IntOrBool type that treat no=0 and yes=1,
2. Change the implementation to check for and add N newlines, when newline_separated=N is specified,
3. Add new test cases.

Tested :
```
$ go test ./...
?       github.com/google/keep-sorted   [no test files]
?       github.com/google/keep-sorted/cmd       [no test files]
ok      github.com/google/keep-sorted/goldens   (cached)
ok      github.com/google/keep-sorted/keepsorted        (cached)
```