### PR TITLE
refactor: Rename some methods and types related to ByRegex.

### DIFF
--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -374,8 +374,8 @@ func (b block) lessFn() cmpFunc[lineGroup] {
 		return 1
 	})
 
-	regexTransform := func(lg lineGroup) []regexToken {
-		return b.metadata.opts.regexTransform(lg.joinedLines())
+	regexTransform := func(lg lineGroup) []regexMatch {
+		return b.metadata.opts.matchRegexes(lg.joinedLines())
 	}
 
 	ord := newPrefixOrder(b.metadata.opts)
@@ -413,6 +413,6 @@ func (b block) lessFn() cmpFunc[lineGroup] {
 	}, numericTokens.compare)
 
 	return commentOnlyBlock.
-		andThen(comparingFunc(regexTransform, compareRegexTokens(prefixOrder.andThen(lexicographically(transformOrder))))).
+		andThen(comparingFunc(regexTransform, compareRegexMatches(prefixOrder.andThen(lexicographically(transformOrder))))).
 		andThen(lineGroup.less)
 }

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -15,6 +15,7 @@
 package keepsorted
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"iter"
@@ -477,4 +478,43 @@ func (t numericTokens) compare(o numericTokens) int {
 	// If the numericTokens are all the same, whichever numericTokens that's
 	// smaller is less than the other.
 	return t.len() - o.len()
+}
+
+type prefixOrder struct {
+	opts          blockOptions
+	prefixWeights map[string]int
+	prefixes      []string
+}
+
+func newPrefixOrder(opts blockOptions) *prefixOrder {
+	// Assign a weight to each prefix so that they will be sorted into their
+	// predetermined order.
+	// Weights are negative so that entries with matching prefixes are put before
+	// any non-matching line (which will have a weight of 0).
+	//
+	// An empty prefix can be used to move "non-matching" entries to a position
+	// between other prefixes.
+	prefixWeights := make(map[string]int)
+	for i, p := range opts.PrefixOrder {
+		prefixWeights[p] = i - len(opts.PrefixOrder)
+	}
+	// Sort prefixes longest -> shortest to find the most appropriate weight.
+	longestFirst := comparing(func(s string) int { return len(s) }).reversed()
+	prefixes := slices.SortedStableFunc(slices.Values(opts.PrefixOrder), longestFirst)
+
+	return &prefixOrder{opts, prefixWeights, prefixes}
+}
+
+func (o prefixOrder) match(s string) orderedPrefix {
+	pre, _ := o.opts.hasPrefix(s, slices.Values(o.prefixes))
+	return orderedPrefix{pre, o.prefixWeights[pre]}
+}
+
+type orderedPrefix struct {
+	prefix string
+	weight int
+}
+
+func (pre orderedPrefix) compare(other orderedPrefix) int {
+	return cmp.Compare(pre.weight, other.weight)
 }

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -294,13 +294,13 @@ func TestBlockOptions_regexTransform(t *testing.T) {
 				opts.ByRegex = append(opts.ByRegex, regexp.MustCompile(regex))
 			}
 
-			gotTokens := opts.regexTransform(tc.in)
+			gotTokens := opts.matchRegexes(tc.in)
 			got := make([][]string, len(gotTokens))
 			for i, t := range gotTokens {
 				got[i] = []string(t)
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("%q.regexTransform(%q) diff (-want +got)\n%s", opts, tc.in, diff)
+				t.Errorf("%q.matchRegexes(%q) diff (-want +got)\n%s", opts, tc.in, diff)
 			}
 		})
 	}


### PR DESCRIPTION
I think "regexMatch" makes more sense than "regexToken" because we aren't doing anything special to the raw regex match.

I like "regexDidNotMatch" better than "alwaysLast" since the former actually describes how we get that value instead of the business logic implications.