### PR TITLE
chore: Finish bumping go's version to 1.23.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
 
       - name: Build
         run: go build -v .

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
 
       - name: Build
         run: go build -v .


### PR DESCRIPTION
This was overlooked in 71c288e2c0720cc0929d791e41fa3a4f28d61a6f (#39).

This didn't cause any problems that I noticed, but I thought it was odd that the github actions weren't using the version advertised in the readme.