### PR TITLE
Add blank_lines_as_separators option

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,28 @@ Pineapples
 </tr>
 </table>
 
+#### Blank line separators
+
+The `blank_lines_as_separators=yes` option treats blank lines as block separators. Lines within each block are sorted internally, then blocks are sorted relative to each other while preserving the blank lines between them.
+
+This is useful for sorting groups of related lines:
+
+```diff
+ // keep-sorted start blank_lines_as_separators=yes
+ kAccelerateName="Accelerate"
+ kAccelerateDescription="Speed up"
+ 
+-kTurnName="Turn"
+-kTurnDescription="Change direction"
+-
+ kBrakeName="Brake"
+ kBrakeDescription="Slow down"
++
++kTurnName="Turn"
++kTurnDescription="Change direction"
+ // keep-sorted end
+```
+
 ### Syntax
 
 If you find yourself wanting to include special characters (spaces, commas, left

--- a/goldens/blank_lines_as_separators.in
+++ b/goldens/blank_lines_as_separators.in
@@ -1,0 +1,12 @@
+// keep-sorted-test start by_regex=(k[A-Za-z0-9_]+)(?:Name|Description),(Name|Description) prefix_order=Name skip_lines=2 block=yes blank_lines_as_separators=yes
+
+kAccelerateName="Accelerate"
+kAccelerateDescription="When pressed, moves faster."
+
+kTurnName="Turn left or right"
+kTurnDescription="When used, changes direction."
+
+kDecelerateDescription="When pressed, brakes."
+kDecelerateName="Decelerate"
+
+// keep-sorted-test end

--- a/goldens/blank_lines_as_separators.out
+++ b/goldens/blank_lines_as_separators.out
@@ -1,0 +1,12 @@
+// keep-sorted-test start by_regex=(k[A-Za-z0-9_]+)(?:Name|Description),(Name|Description) prefix_order=Name skip_lines=2 block=yes blank_lines_as_separators=yes
+
+kAccelerateName="Accelerate"
+kAccelerateDescription="When pressed, moves faster."
+
+kDecelerateName="Decelerate"
+kDecelerateDescription="When pressed, brakes."
+
+kTurnName="Turn left or right"
+kTurnDescription="When used, changes direction."
+
+// keep-sorted-test end

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -1264,6 +1264,104 @@ func TestLineSorting(t *testing.T) {
 			},
 			wantAlreadySorted: true,
 		},
+		{
+			name: "BlankLinesAsSeparators_AlreadySorted",
+
+			opts: blockOptions{BlankLinesAsSeparators: true},
+			in: []string{
+				"Apple",
+				"Apricot",
+				"",
+				"Banana",
+				"Berry",
+				"",
+				"Cherry",
+				"Coconut",
+			},
+
+			want: []string{
+				"Apple",
+				"Apricot",
+				"",
+				"Banana",
+				"Berry",
+				"",
+				"Cherry",
+				"Coconut",
+			},
+			wantAlreadySorted: true,
+		},
+		{
+			name: "BlankLinesAsSeparators_NeedsSorting",
+
+			opts: blockOptions{BlankLinesAsSeparators: true},
+			in: []string{
+				"Coconut",
+				"Cherry",
+				"",
+				"Berry",
+				"Banana",
+				"",
+				"Apricot",
+				"Apple",
+			},
+
+			want: []string{
+				"Apple",
+				"Apricot",
+				"",
+				"Banana",
+				"Berry",
+				"",
+				"Cherry",
+				"Coconut",
+			},
+			wantAlreadySorted: false,
+		},
+		{
+			name: "BlankLinesAsSeparators_WithInternalSorting",
+
+			opts: blockOptions{BlankLinesAsSeparators: true},
+			in: []string{
+				"zebra",
+				"apple",
+				"",
+				"dog",
+				"cat",
+				"",
+				"orange",
+				"banana",
+			},
+
+			want: []string{
+				"apple",
+				"zebra",
+				"",
+				"banana",
+				"orange",
+				"",
+				"cat",
+				"dog",
+			},
+			wantAlreadySorted: false,
+		},
+		{
+			name: "BlankLinesAsSeparators_NoBlankLines",
+
+			opts: blockOptions{BlankLinesAsSeparators: true},
+			in: []string{
+				"zebra",
+				"apple",
+				"cat",
+			},
+
+			want: []string{
+				"apple",
+				"cat",
+				"zebra",
+			},
+			wantAlreadySorted: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			initZerolog(t)

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -116,6 +116,8 @@ type blockOptions struct {
 	NewlineSeparated IntOrBool `key:"newline_separated"`
 	// RemoveDuplicates determines whether we drop lines that are an exact duplicate.
 	RemoveDuplicates bool `key:"remove_duplicates"`
+	// BlankLinesAsSeparators indicates that blank lines should be treated as block separators.
+	BlankLinesAsSeparators bool `key:"blank_lines_as_separators"`
 
 	// Syntax used to start a comment for keep-sorted annotation, e.g. "//".
 	commentMarker string

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -94,6 +94,18 @@ func TestBlockOptions(t *testing.T) {
 			wantErr: "newline_separated has invalid value: -1",
 		},
 		{
+			name: "BlankLinesAsSeparators_True",
+			in:   "blank_lines_as_separators=yes",
+
+			want: blockOptions{BlankLinesAsSeparators: true},
+		},
+		{
+			name: "BlankLinesAsSeparators_False",
+			in:   "blank_lines_as_separators=no",
+
+			want: blockOptions{BlankLinesAsSeparators: false},
+		},
+		{
 			name: "ErrorSkipLinesIsNegative",
 			in:   "skip_lines=-1",
 


### PR DESCRIPTION
Add support for blank_lines_as_separators=yes option which treats blank lines in the input as block separators. When enabled, keep-sorted will:

- Split input into blocks separated by blank lines
- Sort lines within each block according to configured options
- Sort blocks themselves based on their content
- Preserve blank lines between sorted blocks

This is useful for sorting groups of related lines while maintaining visual separation, such as Name/Description pairs or related constants.

The implementation includes:
- New BlankLinesAsSeparators option in blockOptions
- Specialized sorting logic in sortBlankLineSeparatedBlocks()
- Helper functions for block splitting and sorting
- Comprehensive documentation in README.md
- Golden test coverage

This change permits enforcing sort order for more complex content, such as https://crsrc.org/c/chrome/browser/flag_descriptions.h

#ai-assisted