### PR TITLE
refactor: Simplify some conditional logic to remove unreachable branches.

### DIFF
--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -137,17 +137,13 @@ func groupLines(lines []string, metadata blockMetadata) []*lineGroup {
 				finishGroup()
 			}
 
-			if metadata.opts.Group && strings.Contains(l, metadata.startDirective) {
-				// We don't need to check for end directives here because this makes
-				// numUnmatchedStartDirectives > 0, so we'll take the code path above through appendLine.
-				if lineRange.empty() {
-					commentRange.append(i)
-					countStartDirectives(l)
-				} else {
-					appendLine(i, l)
-				}
-			} else {
-				commentRange.append(i)
+			commentRange.append(i)
+			if metadata.opts.Group {
+				// Note: This will not count end directives. If this call ever finds a
+				// start directive, it will set numUnmatchedStartDirectives > 0 and then
+				// we will enter the branch above where we'll count end directives via
+				// its appendLine call.
+				countStartDirectives(l)
 			}
 		} else {
 			if !lineRange.empty() {


### PR DESCRIPTION
```
if !lineRange.empty() {
  finishGroup()
}
```

guarantees that `lineRange.empty()` will be true after it (`finishGroup` zeroes out `lineRange`). That lets us get rid of one of the branches in the `metadata.opts.Group` conditional. But now the remaining branch shares a lot in common with the `else` branch, so we can simplify a bit further.