### PR TITLE
fix: Apply regexes to the actual line content (separated by newlines) instead of the joinedLines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,11 @@ option `by_regex=…` takes a comma-separated list of [RE2 regular
 expressions] that will be applied to the group, and then sorting
 will take place on just the results of the regular expressions.
 
+> [!NOTE]
+> By default, keep-sorted adds the `s` flag to all regular expressions that
+> allows `.` to also match `\n`. If you do not want that behavior, add `(?-s)`
+> to the start of your regular expression.
+
 > [!TIP]
 > Regular expressions often need special characters. See [Syntax](#syntax) below
 > for how to include special characters in the `by_regex` option.

--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -492,7 +492,7 @@ func (lg *lineGroup) internalJoinedLines() string {
 	return s.String()
 }
 
-// regexJoinedLines concatenates all of this lineGroup's content in a way that
+// regexJoinedLines concatenates all of this lineGroup's content in a way that's
 // friendlier to regexes than internalJoinedLines.
 //
 // Primarily, this method still strips leading whitespace but it uses a real

--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -430,8 +430,7 @@ func (lg *lineGroup) regexTokens() []regexToken {
 	} else {
 		regexMatches = lg.opts.matchRegexes(lg.regexJoinedLines())
 		// We still want to apply the joinLines transform so that we get
-		// "reasonable human" comparisons if the regex intentionally
-		// (or accidentally!) matches more than one line.
+		// "reasonable human" comparisons if the regex matches more than one line.
 		for _, match := range regexMatches {
 			for i, s := range match {
 				match[i] = joinLines(strings.Split(s, "\n"))

--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -429,6 +429,14 @@ func (lg *lineGroup) regexTokens() []regexToken {
 		regexMatches = []regexMatch{{lg.internalJoinedLines()}}
 	} else {
 		regexMatches = lg.opts.matchRegexes(lg.regexJoinedLines())
+		// We still want to apply the joinLines transform so that we get
+		// "reasonable human" comparisons if the regex intentionally
+		// (or accidentally!) matches more than one line.
+		for _, match := range regexMatches {
+			for i, s := range match {
+				match[i] = joinLines(strings.Split(s, "\n"))
+			}
+		}
 	}
 
 	ret := make([]regexToken, len(regexMatches))
@@ -473,7 +481,11 @@ func (lg *lineGroup) regexTokens() []regexToken {
 // Unlike joinedLines, this method does not record that it was used in the
 // accessRecorder.
 func (lg *lineGroup) internalJoinedLines() string {
-	if len(lg.lines) == 0 {
+	return joinLines(lg.lines)
+}
+
+func joinLines(lines []string) string {
+	if len(lines) == 0 {
 		return ""
 	}
 
@@ -481,7 +493,7 @@ func (lg *lineGroup) internalJoinedLines() string {
 	startsWithWordChar := regexp.MustCompile(`^\w`)
 	var s strings.Builder
 	var last string
-	for _, l := range lg.lines {
+	for _, l := range lines {
 		l := strings.TrimLeftFunc(l, unicode.IsSpace)
 		if len(last) > 0 && len(l) > 0 && endsWithWordChar.MatchString(last) && startsWithWordChar.MatchString(l) {
 			s.WriteString(" ")

--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -119,7 +119,7 @@ func groupLines(lines []string, metadata blockMetadata) []*lineGroup {
 	// Returns another boolean indicating whether the group should be ending
 	// after that line if so.
 	shouldAddToRegexDelimitedGroup := func(l string) (addToGroup bool, finishGroupAfter bool) {
-        if metadata.opts.GroupStartRegex != nil {
+		if metadata.opts.GroupStartRegex != nil {
 			// For GroupStartRegex, all non-regex-matching lines should be
 			// part of the group including prior lines.
 			return !matchesAnyRegex(l, metadata.opts.GroupStartRegex), false
@@ -349,7 +349,7 @@ func (cb *codeBlock) append(s string, opts blockOptions) {
 		cb.braceCounts = make(map[string]int)
 	}
 
-	// TODO(jfalgout): Does this need to handle runes more correctly?
+	// TODO: jfaer - Does this need to handle runes more correctly?
 	for i := 0; i < len(s); {
 		if cb.expectedQuote == "" {
 			// We do not appear to be inside a string literal.
@@ -419,8 +419,18 @@ func (lg *lineGroup) commentOnly() bool {
 }
 
 func (lg *lineGroup) regexTokens() []regexToken {
-	// TODO: jfaer - Should we match regexes on the original content?
-	regexMatches := lg.opts.matchRegexes(lg.internalJoinedLines())
+	var regexMatches []regexMatch
+	if len(lg.opts.ByRegex) == 0 {
+		// We apply other options on top of what the regex extracts, but if the user
+		// didn't set by_regex, we should fall back to the behavior they would've
+		// expected before we started supporting by_regex.
+		// Namely: We would apply the other options on top of the
+		// internalJoinedLines() instead of the raw content.
+		regexMatches = []regexMatch{{lg.internalJoinedLines()}}
+	} else {
+		regexMatches = lg.opts.matchRegexes(lg.regexJoinedLines())
+	}
+
 	ret := make([]regexToken, len(regexMatches))
 	if lg.access.regexTokens == nil {
 		lg.access.regexTokens = make([]regexTokenAccessRecorder, len(regexMatches))
@@ -453,8 +463,15 @@ func (lg *lineGroup) regexTokens() []regexToken {
 	return ret
 }
 
-// internalJoinedLines calculates the same thing as joinedLines, except it
-// doesn't record that it was used in the accessRecorder.
+// internalJoinedLines attempts to concatenate all of this lineGroup's content
+// the same way a reasonable human might.
+//
+// If the previous line ends with a "word" character and the current line starts
+// with a "word" character, the two lines will be separated by a space.
+// Otherwise, the lines are concatenated without any separation.
+//
+// Unlike joinedLines, this method does not record that it was used in the
+// accessRecorder.
 func (lg *lineGroup) internalJoinedLines() string {
 	if len(lg.lines) == 0 {
 		return ""
@@ -475,6 +492,25 @@ func (lg *lineGroup) internalJoinedLines() string {
 	return s.String()
 }
 
+// regexJoinedLines concatenates all of this lineGroup's content in a way that
+// friendlier to regexes than internalJoinedLines.
+//
+// Primarily, this method still strips leading whitespace but it uses a real
+// newline character to separate lines instead of the "word" character logic of
+// internalJoinedLines.
+func (lg *lineGroup) regexJoinedLines() string {
+	if len(lg.lines) == 0 {
+		return ""
+	}
+	lines := make([]string, len(lg.lines))
+	for i, l := range lg.lines {
+		lines[i] = strings.TrimLeftFunc(l, unicode.IsSpace)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// joinedLines returns internalJoinedLines and records that it was called in the
+// accessRecorder.
 func (lg *lineGroup) joinedLines() string {
 	lg.access.joinedLines = true
 	return lg.internalJoinedLines()

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -238,21 +238,25 @@ func formatValue(val reflect.Value) (string, error) {
 		return strconv.Itoa(int(val.Int())), nil
 	case reflect.TypeFor[[]ByRegexOption]():
 		opts := val.Interface().([]ByRegexOption)
-		vals := make([]string, 0, len(opts))
+		vals := make([]any, len(opts))
 		seenTemplate := false
-		for _, opt := range opts {
+		for i, opt := range opts {
 			if opt.Template != nil {
 				seenTemplate = true
-				vals = append(vals, fmt.Sprintf(`%q: %q`, opt.Pattern.String(), *opt.Template))
+				vals[i] = map[string]string{opt.Pattern.String(): *opt.Template}
 				continue
 			}
-			vals = append(vals, opt.Pattern.String())
+			vals[i] = opt.Pattern.String()
 		}
 		if seenTemplate {
 			// always presented as a yaml sequence to preserve any `k:v` items
-			return fmt.Sprintf("[%s]", strings.Join(vals, ", ")), nil
+			return formatYAMLList(vals)
 		}
-		return formatList(vals)
+		s := make([]string, len(vals))
+		for i, val := range vals {
+			s[i] = val.(string)
+		}
+		return formatList(s)
 	case reflect.TypeFor[[]*regexp.Regexp]():
 		regexps := val.Interface().([]*regexp.Regexp)
 		vals := make([]string, len(regexps))
@@ -282,6 +286,10 @@ func formatList(vals []string) (string, error) {
 		return strings.Join(vals, ","), nil
 	}
 
+	return formatYAMLList(vals)
+}
+
+func formatYAMLList[T any](vals []T) (string, error) {
 	node := new(yaml.Node)
 	if err := node.Encode(vals); err != nil {
 		return "", fmt.Errorf("while converting list to YAML: %w", err)

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -40,6 +40,14 @@ type ByRegexOption struct {
 	Template *string
 }
 
+func (opt ByRegexOption) MarshalYAML() (any, error) {
+	if opt.Template == nil {
+		return opt.Pattern.String(), nil
+	}
+
+	return map[string]string{opt.Pattern.String(): *opt.Template}, nil
+}
+
 // SortOrder defines whether we sort in ascending or descending order.
 type SortOrder string
 
@@ -238,25 +246,20 @@ func formatValue(val reflect.Value) (string, error) {
 		return strconv.Itoa(int(val.Int())), nil
 	case reflect.TypeFor[[]ByRegexOption]():
 		opts := val.Interface().([]ByRegexOption)
-		vals := make([]any, len(opts))
+		vals := make([]string, len(opts))
 		seenTemplate := false
 		for i, opt := range opts {
 			if opt.Template != nil {
 				seenTemplate = true
-				vals[i] = map[string]string{opt.Pattern.String(): *opt.Template}
-				continue
+				break
 			}
 			vals[i] = opt.Pattern.String()
 		}
 		if seenTemplate {
 			// always presented as a yaml sequence to preserve any `k:v` items
-			return formatYAMLList(vals)
+			return formatYAMLList(opts)
 		}
-		s := make([]string, len(vals))
-		for i, val := range vals {
-			s[i] = val.(string)
-		}
-		return formatList(s)
+		return formatList(vals)
 	case reflect.TypeFor[[]*regexp.Regexp]():
 		regexps := val.Interface().([]*regexp.Regexp)
 		vals := make([]string, len(regexps))

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -437,13 +437,14 @@ func (opts blockOptions) trimIgnorePrefix(s string) string {
 // the resulting slice.
 func (opts blockOptions) matchRegexes(s string) []regexMatch {
 	if len(opts.ByRegex) == 0 {
-		return []regexMatch{{s}}
+		return nil
 	}
 
 	var ret []regexMatch
 	for _, p := range opts.ByRegex {
 		regex := p.Pattern
 
+		// TODO: jfaer - It'd be nice if these two branches were unified.
 		if p.Template != nil {
 			var result []byte
 			m := regex.FindAllStringSubmatchIndex(s, -1)

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -238,21 +238,26 @@ func formatValue(val reflect.Value) (string, error) {
 		return strconv.Itoa(int(val.Int())), nil
 	case reflect.TypeFor[[]ByRegexOption]():
 		opts := val.Interface().([]ByRegexOption)
-		vals := make([]string, 0, len(opts))
+		vals := make([]any, len(opts))
 		seenTemplate := false
-		for _, opt := range opts {
+		for i, opt := range opts {
 			if opt.Template != nil {
 				seenTemplate = true
-				vals = append(vals, fmt.Sprintf(`%q: %q`, opt.Pattern.String(), *opt.Template))
+				vals[i] = map[string]string{opt.Pattern.String(): *opt.Template}
 				continue
 			}
-			vals = append(vals, opt.Pattern.String())
+			vals[i] = opt.Pattern.String()
 		}
+
 		if seenTemplate {
-			// always presented as a yaml sequence to preserve any `k:v` items
-			return fmt.Sprintf("[%s]", strings.Join(vals, ", ")), nil
+			return formatYAMLList(vals)
 		}
-		return formatList(vals)
+
+		s := make([]string, len(vals))
+		for i, val := range vals {
+			s[i] = val.(string)
+		}
+		return formatList(s)
 	case reflect.TypeFor[[]*regexp.Regexp]():
 		regexps := val.Interface().([]*regexp.Regexp)
 		vals := make([]string, len(regexps))
@@ -282,6 +287,10 @@ func formatList(vals []string) (string, error) {
 		return strings.Join(vals, ","), nil
 	}
 
+	return formatYAMLList(vals)
+}
+
+func formatYAMLList[T any](vals []T) (string, error) {
 	node := new(yaml.Node)
 	if err := node.Encode(vals); err != nil {
 		return "", fmt.Errorf("while converting list to YAML: %w", err)

--- a/keepsorted/options_parser.go
+++ b/keepsorted/options_parser.go
@@ -323,7 +323,7 @@ func (iter *runeIter) pop() (rune, bool) {
 }
 
 func compileByRegex(re string) (*regexp.Regexp, error) {
-	if !strings.HasPrefix(re, "(?s)") {
+	if !strings.HasPrefix(re, "(?s)") && !strings.HasPrefix(re, "(?-s)") {
 		// The initial version of by_regex ran on top of lineGroup.joinedLines. This
 		// meant that users wrote regexes that didn't need to handle newlines.
 		// To minimize disruption, we automatically set dotall flag so that their

--- a/keepsorted/options_parser.go
+++ b/keepsorted/options_parser.go
@@ -125,7 +125,7 @@ func (p *parser) popIntOrBool() (IntOrBool, error) {
 func (ar *ByRegexOption) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Tag {
 	case "!!str":
-		pat, err := regexp.Compile(node.Value)
+		pat, err := compileByRegex(node.Value)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (ar *ByRegexOption) UnmarshalYAML(node *yaml.Node) error {
 			return fmt.Errorf("by_regex map item must have exactly one key-value pair, but got %d", len(m))
 		}
 		for pattern, template := range m {
-			pat, err := regexp.Compile(pattern)
+			pat, err := compileByRegex(pattern)
 			if err != nil {
 				return fmt.Errorf("invalid regex pattern %q: %w", pattern, err)
 			}
@@ -191,7 +191,7 @@ func (p *parser) popList() ([]string, error) {
 
 func (p *parser) popByRegexOption() ([]ByRegexOption, error) {
 	return popListValue(p, func(s string) (ByRegexOption, error) {
-		pat, err := regexp.Compile(s)
+		pat, err := compileByRegex(s)
 		return ByRegexOption{Pattern: pat}, err
 	})
 }
@@ -320,4 +320,15 @@ func (iter *runeIter) pop() (rune, bool) {
 		iter.idx += utf8.RuneLen(ch)
 	}
 	return ch, ok
+}
+
+func compileByRegex(re string) (*regexp.Regexp, error) {
+	if !strings.HasPrefix(re, "(?s)") {
+		// The initial version of by_regex ran on top of lineGroup.joinedLines. This
+		// meant that users wrote regexes that didn't need to handle newlines.
+		// To minimize disruption, we automatically set dotall flag so that their
+		// regexes might still work after we start using real newlines.
+		re = "(?s)" + re
+	}
+	return regexp.Compile(re)
 }

--- a/keepsorted/options_parser_test.go
+++ b/keepsorted/options_parser_test.go
@@ -218,7 +218,7 @@ func TestPopValue(t *testing.T) {
 			name: "Regex",
 
 			input: ".*",
-			want:  []ByRegexOption{{regexp.MustCompile(".*"), nil}},
+			want:  []ByRegexOption{{regexp.MustCompile("(?s).*"), nil}},
 		},
 		{
 			name: "MultipleRegex",
@@ -226,9 +226,9 @@ func TestPopValue(t *testing.T) {
 			input:         `[.*, abcd, '(?:efgh)ijkl']`,
 			allowYAMLList: true,
 			want: []ByRegexOption{
-				{regexp.MustCompile(".*"), nil},
-				{regexp.MustCompile("abcd"), nil},
-				{regexp.MustCompile("(?:efgh)ijkl"), nil},
+				{regexp.MustCompile("(?s).*"), nil},
+				{regexp.MustCompile("(?s)abcd"), nil},
+				{regexp.MustCompile("(?s)(?:efgh)ijkl"), nil},
 			},
 		},
 		{
@@ -237,10 +237,10 @@ func TestPopValue(t *testing.T) {
 			input:         `[.*, Mon: 0, '\b(\d{2})/(\d{2})/(\d{4})\b': '${3}-${1}-${2}', "0: 1": 2]`,
 			allowYAMLList: true,
 			want: []ByRegexOption{
-				{regexp.MustCompile(".*"), nil},
-				{regexp.MustCompile("Mon"), &([]string{"0"})[0]},
-				{regexp.MustCompile(`\b(\d{2})/(\d{2})/(\d{4})\b`), &([]string{"${3}-${1}-${2}"})[0]},
-				{regexp.MustCompile(`0: 1`), &([]string{"2"})[0]},
+				{regexp.MustCompile("(?s).*"), nil},
+				{regexp.MustCompile("(?s)Mon"), &([]string{"0"})[0]},
+				{regexp.MustCompile(`(?s)\b(\d{2})/(\d{2})/(\d{4})\b`), &([]string{"${3}-${1}-${2}"})[0]},
+				{regexp.MustCompile(`(?s)0: 1`), &([]string{"2"})[0]},
 			},
 		},
 		{

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -221,8 +221,8 @@ func TestBlockOptions(t *testing.T) {
 			want: blockOptions{
 				AllowYAMLLists: true,
 				ByRegex: []ByRegexOption{
-					{Pattern: regexp.MustCompile(`foo, bar`)},
-					{Pattern: regexp.MustCompile(`\b(\d{2})/(\d{2})/(\d{4})\b`),
+					{Pattern: regexp.MustCompile(`(?s)foo, bar`)},
+					{Pattern: regexp.MustCompile(`(?s)\b(\d{2})/(\d{2})/(\d{4})\b`),
 						Template: &[]string{"${3}-${1}-${2}"}[0]},
 				},
 			},

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -194,7 +194,8 @@ func TestBlockOptions(t *testing.T) {
 			want: blockOptions{
 				AllowYAMLLists: true,
 				ByRegex: []ByRegexOption{
-					{regexp.MustCompile("(?:abcd)"), nil}, {regexp.MustCompile("efg.*"), nil},
+					{regexp.MustCompile("(?s)(?:abcd)"), nil},
+					{regexp.MustCompile("(?s)efg.*"), nil},
 				},
 			},
 		},
@@ -206,8 +207,8 @@ func TestBlockOptions(t *testing.T) {
 			want: blockOptions{
 				AllowYAMLLists: true,
 				ByRegex: []ByRegexOption{
-					{Pattern: regexp.MustCompile(`.*`)},
-					{Pattern: regexp.MustCompile(`\b(\d{2})/(\d{2})/(\d{4})\b`),
+					{Pattern: regexp.MustCompile(`(?s).*`)},
+					{Pattern: regexp.MustCompile(`(?s)\b(\d{2})/(\d{2})/(\d{4})\b`),
 						Template: &[]string{"${3}-${1}-${2}"}[0]},
 				},
 			},
@@ -253,13 +254,13 @@ func TestBlockOptions(t *testing.T) {
 			got, warns := parseBlockOptions(tc.commentMarker, tc.in, tc.defaultOptions)
 			if err := errors.Join(warns...); err != nil {
 				if tc.wantErr == "" {
-					t.Errorf("parseBlockOptions(%q, %q) = %v", tc.commentMarker, tc.in, err)
+					t.Errorf("parseBlockOptions(%#v, %#v) = %v", tc.commentMarker, tc.in, err)
 				} else if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Errorf("parseBlockOptions(%q, %q) = %v, expected to contain %q", tc.commentMarker, tc.in, err, tc.wantErr)
+					t.Errorf("parseBlockOptions(%#v, %#v) = %v, expected to contain %q", tc.commentMarker, tc.in, err, tc.wantErr)
 				}
 			}
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(blockOptions{}), cmpRegexp); diff != "" {
-				t.Errorf("parseBlockOptions(%q, %q) mismatch (-want +got):\n%s", tc.commentMarker, tc.in, diff)
+				t.Errorf("parseBlockOptions(%#v, %#v) mismatch (-want +got):\n%s", tc.commentMarker, tc.in, diff)
 			}
 
 			if tc.wantErr == "" {
@@ -267,10 +268,10 @@ func TestBlockOptions(t *testing.T) {
 					s := got.String()
 					got2, warns := parseBlockOptions(tc.commentMarker, s, tc.defaultOptions)
 					if err := errors.Join(warns...); err != nil {
-						t.Errorf("parseBlockOptions(%q, %q) = %v", tc.commentMarker, s, err)
+						t.Errorf("parseBlockOptions(%#v, %#v) = %v", tc.commentMarker, s, err)
 					}
 					if diff := cmp.Diff(got, got2, cmp.AllowUnexported(blockOptions{}), cmpRegexp); diff != "" {
-						t.Errorf("parseBlockOptions(%q, %q) mismatch (-want +got):\n%s", tc.commentMarker, s, diff)
+						t.Errorf("parseBlockOptions(%#v, %#v) mismatch (-want +got):\n%s", tc.commentMarker, s, diff)
 					}
 				})
 			}

--- a/keepsorted/options_test.go
+++ b/keepsorted/options_test.go
@@ -213,6 +213,20 @@ func TestBlockOptions(t *testing.T) {
 			},
 		},
 		{
+			name:           "RegexWithTemplateAndSingletonWithSpecialChars",
+			in:             `by_regex=['foo, bar', '\b(\d{2})/(\d{2})/(\d{4})\b': '${3}-${1}-${2}']`,
+			defaultOptions: blockOptions{AllowYAMLLists: true},
+
+			want: blockOptions{
+				AllowYAMLLists: true,
+				ByRegex: []ByRegexOption{
+					{Pattern: regexp.MustCompile(`foo, bar`)},
+					{Pattern: regexp.MustCompile(`\b(\d{2})/(\d{2})/(\d{4})\b`),
+						Template: &[]string{"${3}-${1}-${2}"}[0]},
+				},
+			},
+		},
+		{
 			name: "OrderAsc",
 			in:   "order=asc",
 			want: blockOptions{Order: OrderAsc},
@@ -253,13 +267,13 @@ func TestBlockOptions(t *testing.T) {
 			got, warns := parseBlockOptions(tc.commentMarker, tc.in, tc.defaultOptions)
 			if err := errors.Join(warns...); err != nil {
 				if tc.wantErr == "" {
-					t.Errorf("parseBlockOptions(%q, %q) = %v", tc.commentMarker, tc.in, err)
+					t.Errorf("parseBlockOptions(%#v, %#v) = %v", tc.commentMarker, tc.in, err)
 				} else if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Errorf("parseBlockOptions(%q, %q) = %v, expected to contain %q", tc.commentMarker, tc.in, err, tc.wantErr)
+					t.Errorf("parseBlockOptions(%#v, %#v) = %v, expected to contain %q", tc.commentMarker, tc.in, err, tc.wantErr)
 				}
 			}
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(blockOptions{}), cmpRegexp); diff != "" {
-				t.Errorf("parseBlockOptions(%q, %q) mismatch (-want +got):\n%s", tc.commentMarker, tc.in, diff)
+				t.Errorf("parseBlockOptions(%#v, %#v) mismatch (-want +got):\n%s", tc.commentMarker, tc.in, diff)
 			}
 
 			if tc.wantErr == "" {
@@ -267,10 +281,10 @@ func TestBlockOptions(t *testing.T) {
 					s := got.String()
 					got2, warns := parseBlockOptions(tc.commentMarker, s, tc.defaultOptions)
 					if err := errors.Join(warns...); err != nil {
-						t.Errorf("parseBlockOptions(%q, %q) = %v", tc.commentMarker, s, err)
+						t.Errorf("parseBlockOptions(%#v, %#v) = %v", tc.commentMarker, s, err)
 					}
 					if diff := cmp.Diff(got, got2, cmp.AllowUnexported(blockOptions{}), cmpRegexp); diff != "" {
-						t.Errorf("parseBlockOptions(%q, %q) mismatch (-want +got):\n%s", tc.commentMarker, s, diff)
+						t.Errorf("parseBlockOptions(%#v, %#v) mismatch (-want +got):\n%s", tc.commentMarker, s, diff)
 					}
 				})
 			}


### PR DESCRIPTION
Now users can craft regexes that would match just the first line of the group or block (or any arbitrary line they desire) which is basically impossible to do right now.

I made the decision to opt all by_regex regexes into the dotall flag `(?s)` that allows `.` to match `\n`. This is to minimize migration pain, and to remove the need for users to set that flag themselves because I imagine users are just about always going to want that flag.

1. Today, by_regex is comparing against joinedLines. Many internal users have already crafted regexes that accidentally span lines. Enabling dotall lets most of those regexes work as is after this PR
2. Either users are sorting individual lines of content, in which they don't care about the dotall flag, or they're sorting groups of lines in which case they will _probably_ prefer dotall so they don't need to explicitly match newlines with `\s` or `\n`.
3. If a user _doesn't_ want this behavior, they can explicitly disable dotall in their regex with `(?-s)`

The primary alternative I considered to this would be to make this (technically) new behavior opt-in instead of forcing it on all users. I played around with the idea of re-using the regex's mutiline flag for that. If the regex set multiline at the top level, it would run against newline joined content. Otherwise it would continue to run against the previous joinedLines content. I decided against this route for two main reasons

1. It felt kind of hacky to borrow the multiline flag like that for this purpose. It has other implications for how the regex is processed, and conceivably a user would want to process newline joined content without those implications
2. I think the newline joined content will be more intuitive to users long-term. One of my internal CLs raised some questions about how by_regex was working because the reviewer thought it would run against the raw content.
    - Arguably, there's still some weirdness here since we're trimming leading whitespace from lines. I'm hoping that doesn't confuse users too much

----

There are >1000 uses of by_regex internally. From the internal regression test, without `(?s)` we got

```
    devtools/keep_sorted/regression_test.go:99:      2 unordered at head, ordered differently with pending and live keep-sorted
    devtools/keep_sorted/regression_test.go:99:     27 ordered at head, unordered with pending keep-sorted
```

with `(?s)` we cut that in half:

```
    devtools/keep_sorted/regression_test.go:99:     14 ordered at head, unordered with pending keep-sorted
```

All 14 of those changed files are a subset of the original 29.

While auditing those 14, there were 4 classes of error:
  - [2] User error: The user wrote a bad regex that was working by accident
  - [3] Lines joined w/o a space: The user wrote a regex that implicitly relied on the fact that we sometimes joined lines without a space between them (thanks [Hyrum](https://www.hyrumslaw.com/)).
    - These errors can be fixed by inserting a `\s*` at the appropriate spot
  - [3] Lines joined w/ a literal space: The user wrote a regex that implicitly relied on the fact that we sometimes joined lines with a literal space instead of a newline
     - These errors can be fixed by replacing a literal space with the whitespace character class: `\s`
  - [6] Users were trying to sort a list of things and some of those elements were a single line while some of those elements were split across multiple lines. This led me to realize that we should be applying the `joinLines` transform _after_ the regex has matched instead of omitting it entirely. That tweak resolved these diffs.