### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: "1.23"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: "1.23"
 


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@v3, actions/setup-go@v3, actions/setup-python@v3, actions/checkout@v4.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Diff](https://github.com/actions/checkout/compare/v3...v6) | go.yml, pre-commit.yml, publish-release-artifacts.yml |
| `actions/setup-go` | [`v3`](https://github.com/actions/setup-go/releases/tag/v3) | [`v6`](https://github.com/actions/setup-go/releases/tag/v6) | [Diff](https://github.com/actions/setup-go/compare/v3...v6) | go.yml, publish-release-artifacts.yml |
| `actions/setup-python` | [`v3`](https://github.com/actions/setup-python/releases/tag/v3) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Diff](https://github.com/actions/setup-python/compare/v3...v6) | pre-commit.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Release Notes

<details>
<summary>Release notes for actions/checkout</summary>

### [v4](https://github.com/actions/checkout/releases/tag/v4)

Prepare release v4.3.0 (https://github.com/actions/checkout/pull/2237)

### [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)

## What's Changed
* Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by @TingluoHuang in https://github.com/actions/checkout/pull/2355
* Fix tag handling: preserve annotations and explicit fetch-tags by @ericsciple in https://github.com/actions/checkout/pull/2356

**Full Changelog**: https://github.com/actions/checkout/compare/v6.0.1...v6.0.2

### [v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)

## What's Changed
* Update all references from v5 and v4 to v6 by @ericsciple in https://github.com/actions/checkout/pull/2314
* Add worktree support for persist-credentials includeIf by @ericsciple in https://github.com/actions/checkout/pull/2327
* Clarify v6 README by @ericsciple in https://github.com/actions/checkout/pull/2328


**Full Changelog**: https://github.com/actions/checkout/compare/v6...v6.0.1

### [v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)

## What's Changed
* Update README to include Node.js 24 support details and requirements by @salmanmkc in https://github.com/actions/checkout/pull/2248
* Persist creds to a separate file by @ericsciple in https://github.com/actions/checkout/pull/2286
* v6-beta by @ericsciple in https://github.com/actions/checkout/pull/2298
* update readme/changelog for v6 by @ericsciple in https://github.com/actions/checkout/pull/2311


**Full Changelog**: https://github.com/actions/checkout/compare/v5.0.

*...truncated*

### [v5.0.1](https://github.com/actions/checkout/releases/tag/v5.0.1)

## What's Changed
* Port v6 cleanup to v5 by @ericsciple in https://github.com/actions/checkout/pull/2301


**Full Changelog**: https://github.com/actions/checkout/compare/v5...v5.0.1

</details>

<details>
<summary>Release notes for actions/setup-go</summary>

### [v6.3.0](https://github.com/actions/setup-go/releases/tag/v6.3.0)

## What's Changed
* Update default Go module caching to use go.mod by @priyagupta108 in https://github.com/actions/setup-go/pull/705
* Fix golang download url to go.dev by @178inaba in https://github.com/actions/setup-go/pull/469


**Full Changelog**: https://github.com/actions/setup-go/compare/v6...v6.3.0

### [v6.2.0](https://github.com/actions/setup-go/releases/tag/v6.2.0)

## What's Changed

### Enhancements
* Example for restore-only cache in documentation  by @aparnajyothi-y in https://github.com/actions/setup-go/pull/696
* Update Node.js version in action.yml by @ccoVeille in https://github.com/actions/setup-go/pull/691
* Documentation update of actions/checkout by @deining in https://github.com/actions/setup-go/pull/683

### Dependency updates
* Upgrade js-yaml from 3.14.1 to 3.14.2 by @dependabot in https://github.com/actions/setup-go/pull/682
* Upgr

*...truncated*

### [v5.6.0](https://github.com/actions/setup-go/releases/tag/v5.6.0)

## What's Changed
* Fall back to downloading from go.dev/dl instead of storage.googleapis.com/golang by @aparnajyothi-y in https://github.com/actions/setup-go/pull/689


**Full Changelog**: https://github.com/actions/setup-go/compare/v5...v5.6.0

### [v4.3.0](https://github.com/actions/setup-go/releases/tag/v4.3.0)

## What's Changed
* Fallback to downloading from go.dev/dl instead of storage.googleapis.com/golang by @aparnajyothi-y in https://github.com/actions/setup-go/pull/690


**Full Changelog**: https://github.com/actions/setup-go/compare/v4...v4.3.0

### [v6.1.0](https://github.com/actions/setup-go/releases/tag/v6.1.0)

## What's Changed

### Enhancements
* Fall back to downloading from go.dev/dl instead of storage.googleapis.com/golang by @nicholasngai in https://github.com/actions/setup-go/pull/665
* Add support for .tool-versions file and update workflow by @priya-kinthali in https://github.com/actions/setup-go/pull/673
* Add comprehensive breaking changes documentation for v6 by @mahabaleshwars in https://github.com/actions/setup-go/pull/674

### Dependency updates
* Upgrade eslint-config-prettier f

*...truncated*

</details>

<details>
<summary>Release notes for actions/setup-python</summary>

### [v6.2.0](https://github.com/actions/setup-python/releases/tag/v6.2.0)

## What's Changed
### Dependency Upgrades
* Upgrade dependencies to Node 24 compatible versions by @salmanmkc in https://github.com/actions/setup-python/pull/1259
* Upgrade urllib3 from 2.5.0 to 2.6.3 in `/__tests__/data` by @dependabot in https://github.com/actions/setup-python/pull/1253 and https://github.com/actions/setup-python/pull/1264


**Full Changelog**: https://github.com/actions/setup-python/compare/v6...v6.2.0

### [v6.1.0](https://github.com/actions/setup-python/releases/tag/v6.1.0)

## What's Changed
### Enhancements:
* Add support for `pip-install` input by @gowridurgad in https://github.com/actions/setup-python/pull/1201
* Add graalpy early-access and windows builds by @timfel in https://github.com/actions/setup-python/pull/880
### Dependency and Documentation updates:
* Enhanced wording and updated example usage for `allow-prereleases` by @yarikoptic in https://github.com/actions/setup-python/pull/979
* Upgrade urllib3 from 1.26.19 to 2.5.0 and document breaking ch

*...truncated*

### [v6.0.0](https://github.com/actions/setup-python/releases/tag/v6.0.0)

## What's Changed
### Breaking Changes
* Upgrade to node 24 by @salmanmkc in https://github.com/actions/setup-python/pull/1164

Make sure your runner is on version v2.327.1 or later to ensure compatibility with this release. [See Release Notes](https://github.com/actions/runner/releases/tag/v2.327.1)
### Enhancements:
* Add support for `pip-version`  by @priyagupta108 in https://github.com/actions/setup-python/pull/1129
* Enhance reading from .python-version by @krystof-k in https://githu

*...truncated*

### [v5.6.0](https://github.com/actions/setup-python/releases/tag/v5.6.0)

## What's Changed
* Workflow updates related to Ubuntu 20.04 by @aparnajyothi-y in https://github.com/actions/setup-python/pull/1065
* Fix for Candidate Not Iterable Error by @aparnajyothi-y in https://github.com/actions/setup-python/pull/1082
* Upgrade semver and @types/semver by @dependabot in https://github.com/actions/setup-python/pull/1091
* Upgrade prettier from 2.8.8 to 3.5.3 by @dependabot in https://github.com/actions/setup-python/pull/1046
* Upgrade ts-jest from 29.1.2 to 29.3.2 b

*...truncated*

### [v4.9.1](https://github.com/actions/setup-python/releases/tag/v4.9.1)

## What's Changed
* Add workflow file for publishing releases to immutable action package by @aparnajyothi-y in https://github.com/actions/setup-python/pull/1084


**Full Changelog**: https://github.com/actions/setup-python/compare/v4...v4.9.1

</details>

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
