### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `pre-commit/action` | [`v3.0.0`](https://github.com/pre-commit/action/releases/tag/v3.0.0) | [`v3.0.1`](https://github.com/pre-commit/action/releases/tag/v3.0.1) | [Diff](https://github.com/pre-commit/action/compare/v3.0.0...v3.0.1) | pre-commit.yml |

## Release Notes

<details>
<summary>Release notes for pre-commit/action</summary>

### [v3.0.1](https://github.com/pre-commit/action/releases/tag/v3.0.1)

### Misc

- Update actions/cache to v4
    - #190 PR by @SukiCZ.
    - #189 issue by @bakerkj.

</details>

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
