### PR TITLE
feat: Add warning if skip_lines causes empty block

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -237,7 +237,7 @@ func fix(fixer *keepsorted.Fixer, filenames []string, modifiedLines []keepsorted
 			if warn.Lines.Start == warn.Lines.End {
 				log = log.Int("line", warn.Lines.Start)
 			} else {
-				log = log.Int("start", warn.Lines.Start).Int("end", warn.Lines.End)
+				log = log.Ints("[start,end]", []int{warn.Lines.Start, warn.Lines.End})
 			}
 			log.Msg(warn.Message)
 		}

--- a/goldens/skip_lines.err
+++ b/goldens/skip_lines.err
@@ -1,0 +1,4 @@
+WRN block start is at or after end, possibly due to skip_lines [5+1,6-0] line=6
+WRN block start is at or after end, possibly due to skip_lines [9+0,10-1] line=9
+WRN block start is at or after end, possibly due to skip_lines [22+10,26-0] [start,end]=[32,26]
+exit status 1

--- a/goldens/skip_lines.err
+++ b/goldens/skip_lines.err
@@ -1,4 +1,4 @@
-WRN block start is at or after end, possibly due to skip_lines [5+1,6-0] line=6
-WRN block start is at or after end, possibly due to skip_lines [9+0,10-1] line=9
-WRN block start is at or after end, possibly due to skip_lines [22+10,26-0] [start,end]=[32,26]
+WRN block start is at or after end, possibly due to skip_lines [6+1,7-0] [start,end]=[6,7]
+WRN block start is at or after end, possibly due to skip_lines [10+0,11-1] [start,end]=[10,11]
+WRN block start is at or after end, possibly due to skip_lines [23+10,27-0] [start,end]=[23,27]
 exit status 1

--- a/goldens/skip_lines.in
+++ b/goldens/skip_lines.in
@@ -1,5 +1,13 @@
-Skip lines with an empty block:
+Skip no lines with an empty block is ok:
+keep-sorted-test start skip_lines=0
+keep-sorted-test end
+
+Skip lines at start with an empty block:
 keep-sorted-test start skip_lines=1
+keep-sorted-test end
+
+Skip lines at end with an empty block:
+keep-sorted-test start skip_lines=-1
 keep-sorted-test end
 
 Skip two lines:
@@ -11,7 +19,7 @@ b
 a
 // keep-sorted-test end
 
-Number of skipped lines is greater than block size, so block is ignored:
+Number of skipped lines is greater than block size, so skip_lines causes warning:
 // keep-sorted-test start skip_lines=10
 z
 y

--- a/goldens/skip_lines.out
+++ b/goldens/skip_lines.out
@@ -1,5 +1,13 @@
-Skip lines with an empty block:
+Skip no lines with an empty block is ok:
+keep-sorted-test start skip_lines=0
+keep-sorted-test end
+
+Skip lines at start with an empty block:
 keep-sorted-test start skip_lines=1
+keep-sorted-test end
+
+Skip lines at end with an empty block:
+keep-sorted-test start skip_lines=-1
 keep-sorted-test end
 
 Skip two lines:
@@ -11,7 +19,7 @@ b
 c
 // keep-sorted-test end
 
-Number of skipped lines is greater than block size, so block is ignored:
+Number of skipped lines is greater than block size, so skip_lines causes warning:
 // keep-sorted-test start skip_lines=10
 z
 y

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -117,9 +117,9 @@ func (f *Fixer) newBlocks(filename string, lines []string, offset int, include f
 			start.index += opts.startOffset()
 			endIndex += opts.endOffset()
 			if start.index >= endIndex {
-				warnings = append(warnings, finding(filename, start.index, endIndex,
+				warnings = append(warnings, finding(filename, start.index-opts.startOffset()+offset, endIndex-opts.endOffset()+offset,
 					fmt.Sprintf("block start is at or after end, possibly due to skip_lines [%d+%d,%d-%d]",
-						start.index-opts.startOffset(), opts.startOffset(), endIndex-opts.endOffset(), -opts.endOffset())),
+						start.index-opts.startOffset()+offset, opts.startOffset(), endIndex-opts.endOffset()+offset, -opts.endOffset())),
 				)
 				continue
 			}

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -15,6 +15,7 @@
 package keepsorted
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -116,6 +117,10 @@ func (f *Fixer) newBlocks(filename string, lines []string, offset int, include f
 			start.index += opts.startOffset()
 			endIndex += opts.endOffset()
 			if start.index >= endIndex {
+				warnings = append(warnings, finding(filename, start.index, endIndex,
+					fmt.Sprintf("block start is at or after end, possibly due to skip_lines [%d+%d,%d-%d]",
+						start.index-opts.startOffset(), opts.startOffset(), endIndex-opts.endOffset(), -opts.endOffset())),
+				)
 				continue
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/google/keep-sorted/issues/123

Specifically, this triggers if skip_lines causes the block's start to be at or after the block's end. So fully-empty blocks with no skip_lines (or no-op skip_lines, such as skip_lines=0,0) are still fine.

Modify tests in skip_lines golden test to show this behavior.

Modify how start and end are logged in cmd.go. As-is causes the slightly confusing behavior that "end" is always logged before start because it comes first alphabetically. Now these are logged as [start,end]=[x,y].

The warning for if start>=end shows both the original start/end and their offsets to make it more obvious how the values are arrived at. This helps finding the problematic lines, as otherwise you just see where the block start and end is, not where the directives are.