### PR TITLE
Better handle trailing commas with comments

### DIFF
--- a/goldens/trailing_commas.in
+++ b/goldens/trailing_commas.in
@@ -16,18 +16,26 @@ Trailing comma and a comment
 Trailing comma except for last, last has a comment
   keep-sorted-test start
   3,
-  1,
-  2  # two
+  1, <!-- one -->
+  2  <!-- two -->
   keep-sorted-test end
 
 Trailing comma and a comment, last has a comment
   keep-sorted-test start
-  3, # three
+  3, -- three
   1,
-  2  # two
+  2  -- two
+  keep-sorted-test end
+
+Trailing commas with inline comment
+  keep-sorted-test start
+  "c" /* c */,
+  "b",
+  "a" /* a */
   keep-sorted-test end
 
 Trailing commas with quoted comment characters
+TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   "c",
   "b, //",

--- a/goldens/trailing_commas.in
+++ b/goldens/trailing_commas.in
@@ -7,7 +7,6 @@ Trailing comma except for last
 
 
 Trailing comma and a comment
-TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   3, # three
   1,
@@ -15,7 +14,6 @@ TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test end
 
 Trailing comma except for last, last has a comment
-TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   3,
   1,
@@ -23,9 +21,15 @@ TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test end
 
 Trailing comma and a comment, last has a comment
-TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   3, # three
   1,
   2  # two
+  keep-sorted-test end
+
+Trailing commas with quoted comment characters
+  keep-sorted-test start
+  "c",
+  "b, //",
+  "a, #"
   keep-sorted-test end

--- a/goldens/trailing_commas.out
+++ b/goldens/trailing_commas.out
@@ -1,8 +1,8 @@
 Trailing comma except for last
   keep-sorted-test start
   1,
-  2,
-  3
+  2, 
+  3 
   keep-sorted-test end
 
 
@@ -10,22 +10,22 @@ Trailing comma and a comment
 TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   1,
-  2
-  3, # three
+  2, 
+  3  # three
   keep-sorted-test end
 
 Trailing comma except for last, last has a comment
 TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   1,
-  2  # two,
-  3
+  2, # two
+  3 
   keep-sorted-test end
 
 Trailing comma and a comment, last has a comment
 TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   1,
-  2  # two
-  3, # three
+  2, # two
+  3  # three
   keep-sorted-test end

--- a/goldens/trailing_commas.out
+++ b/goldens/trailing_commas.out
@@ -10,24 +10,32 @@ Trailing comma and a comment
   keep-sorted-test start
   1,
   2,
-  3  # three
+  3 # three
   keep-sorted-test end
 
 Trailing comma except for last, last has a comment
   keep-sorted-test start
-  1,
-  2, # two
+  1, <!-- one -->
+  2,  <!-- two -->
   3
   keep-sorted-test end
 
 Trailing comma and a comment, last has a comment
   keep-sorted-test start
   1,
-  2, # two
-  3  # three
+  2,  -- two
+  3 -- three
+  keep-sorted-test end
+
+Trailing commas with inline comment
+  keep-sorted-test start
+  "a", /* a */
+  "b",
+  "c" /* c */
   keep-sorted-test end
 
 Trailing commas with quoted comment characters
+TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   "a, #"
   "b, //",

--- a/goldens/trailing_commas.out
+++ b/goldens/trailing_commas.out
@@ -1,8 +1,8 @@
 Trailing comma except for last
   keep-sorted-test start
   1,
-  2, 
-  3 
+  2,
+  3
   keep-sorted-test end
 
 
@@ -10,7 +10,7 @@ Trailing comma and a comment
 TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   1,
-  2, 
+  2,
   3  # three
   keep-sorted-test end
 
@@ -19,7 +19,7 @@ TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   1,
   2, # two
-  3 
+  3
   keep-sorted-test end
 
 Trailing comma and a comment, last has a comment

--- a/goldens/trailing_commas.out
+++ b/goldens/trailing_commas.out
@@ -7,7 +7,6 @@ Trailing comma except for last
 
 
 Trailing comma and a comment
-TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   1,
   2,
@@ -15,7 +14,6 @@ TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test end
 
 Trailing comma except for last, last has a comment
-TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   1,
   2, # two
@@ -23,9 +21,15 @@ TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test end
 
 Trailing comma and a comment, last has a comment
-TODO: https://github.com/google/keep-sorted/issues/33 - Fix this
   keep-sorted-test start
   1,
   2, # two
   3  # three
+  keep-sorted-test end
+
+Trailing commas with quoted comment characters
+  keep-sorted-test start
+  "a, #"
+  "b, //",
+  "c",
   keep-sorted-test end

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -391,12 +391,20 @@ func handleTrailingComma(lgs []*lineGroup) (trimTrailingComma func([]*lineGroup)
 	}
 
 	if n := len(dataGroups); n > 1 && allEndInComma(dataGroups[0:n-1]) && !endInComma(dataGroups[n-1]) {
-		dataGroups[n-1].replaceSuffix(possibleCommentLineEnd, ", $2")
+		if dataGroups[n-1].matchesSuffix(commentLineEnd) {
+			dataGroups[n-1].replaceSuffix(commentLineEnd, ", $2")
+		} else {
+			dataGroups[n-1].append(",")
+		}
 
 		return func(lgs []*lineGroup) {
 			for i := len(lgs) - 1; i >= 0; i-- {
 				if len(lgs[i].lines) > 0 {
-					lgs[i].replaceSuffix(commaLineEnd, " $2")
+					if lgs[i].matchesSuffix(commentLineEnd) {
+						lgs[i].replaceSuffix(commaLineEnd, "  $3")
+					} else {
+						lgs[i].trimSuffix(",")
+					}
 					return
 				}
 			}
@@ -416,8 +424,8 @@ func allEndInComma(lgs []*lineGroup) bool {
 }
 
 var (
-	commaLineEnd           = regexp.MustCompile("(,)(\\s*(#|//).*)?$")
-	possibleCommentLineEnd = regexp.MustCompile("( +)?((#|//).*)?$")
+	commaLineEnd   = regexp.MustCompile("(,)( *)((#|//).*)?$")
+	commentLineEnd = regexp.MustCompile("( *)((#|//).*)$")
 )
 
 func endInComma(lg *lineGroup) bool {

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -390,7 +390,10 @@ func handleTrailingComma(lgs []*lineGroup) (trimTrailingComma func([]*lineGroup)
 		}
 	}
 
-	if n := len(dataGroups); n > 1 && allEndInComma(dataGroups[0:n-1]) && !dataGroups[n-1].matchesSuffix(commaLineEnd) {
+	commaLineEnd := regexp.MustCompile("(,)( *)((#|//).*)?$")
+	commentLineEnd := regexp.MustCompile("( *)((#|//).*)$")
+
+	if n := len(dataGroups); n > 1 && allMatchSuffix(dataGroups[0:n-1], commaLineEnd) && !dataGroups[n-1].matchesSuffix(commaLineEnd) {
 		if dataGroups[n-1].matchesSuffix(commentLineEnd) {
 			dataGroups[n-1].replaceSuffix(commentLineEnd, ", $2")
 		} else {
@@ -414,16 +417,11 @@ func handleTrailingComma(lgs []*lineGroup) (trimTrailingComma func([]*lineGroup)
 	return func([]*lineGroup) {}
 }
 
-func allEndInComma(lgs []*lineGroup) bool {
+func allMatchSuffix(lgs []*lineGroup, suffix *regexp.Regexp) bool {
 	for _, lg := range lgs {
-		if !lg.matchesSuffix(commaLineEnd) {
+		if !lg.matchesSuffix(suffix) {
 			return false
 		}
 	}
 	return true
 }
-
-var (
-	commaLineEnd   = regexp.MustCompile("(,)( *)((#|//).*)?$")
-	commentLineEnd = regexp.MustCompile("( *)((#|//).*)$")
-)

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -16,6 +16,7 @@ package keepsorted
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -389,13 +390,13 @@ func handleTrailingComma(lgs []*lineGroup) (trimTrailingComma func([]*lineGroup)
 		}
 	}
 
-	if n := len(dataGroups); n > 1 && allHaveSuffix(dataGroups[0:n-1], ",") && !dataGroups[n-1].hasSuffix(",") {
-		dataGroups[n-1].append(",")
+	if n := len(dataGroups); n > 1 && allEndInComma(dataGroups[0:n-1]) && !endInComma(dataGroups[n-1]) {
+		dataGroups[n-1].replaceSuffix(possibleCommentLineEnd, ", $2")
 
 		return func(lgs []*lineGroup) {
 			for i := len(lgs) - 1; i >= 0; i-- {
 				if len(lgs[i].lines) > 0 {
-					lgs[i].trimSuffix(",")
+					lgs[i].replaceSuffix(commaLineEnd, " $2")
 					return
 				}
 			}
@@ -405,11 +406,20 @@ func handleTrailingComma(lgs []*lineGroup) (trimTrailingComma func([]*lineGroup)
 	return func([]*lineGroup) {}
 }
 
-func allHaveSuffix(lgs []*lineGroup, s string) bool {
+func allEndInComma(lgs []*lineGroup) bool {
 	for _, lg := range lgs {
-		if !lg.hasSuffix(s) {
+		if !endInComma(lg) {
 			return false
 		}
 	}
 	return true
+}
+
+var (
+	commaLineEnd           = regexp.MustCompile("(,)(\\s*(#|//).*)?$")
+	possibleCommentLineEnd = regexp.MustCompile("( +)?((#|//).*)?$")
+)
+
+func endInComma(lg *lineGroup) bool {
+	return lg.matchesSuffix(commaLineEnd)
 }

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -390,7 +390,7 @@ func handleTrailingComma(lgs []*lineGroup) (trimTrailingComma func([]*lineGroup)
 		}
 	}
 
-	if n := len(dataGroups); n > 1 && allEndInComma(dataGroups[0:n-1]) && !endInComma(dataGroups[n-1]) {
+	if n := len(dataGroups); n > 1 && allEndInComma(dataGroups[0:n-1]) && !dataGroups[n-1].matchesSuffix(commaLineEnd) {
 		if dataGroups[n-1].matchesSuffix(commentLineEnd) {
 			dataGroups[n-1].replaceSuffix(commentLineEnd, ", $2")
 		} else {
@@ -416,7 +416,7 @@ func handleTrailingComma(lgs []*lineGroup) (trimTrailingComma func([]*lineGroup)
 
 func allEndInComma(lgs []*lineGroup) bool {
 	for _, lg := range lgs {
-		if !endInComma(lg) {
+		if !lg.matchesSuffix(commaLineEnd) {
 			return false
 		}
 	}
@@ -427,7 +427,3 @@ var (
 	commaLineEnd   = regexp.MustCompile("(,)( *)((#|//).*)?$")
 	commentLineEnd = regexp.MustCompile("( *)((#|//).*)$")
 )
-
-func endInComma(lg *lineGroup) bool {
-	return lg.matchesSuffix(commaLineEnd)
-}

--- a/keepsorted/block.go
+++ b/keepsorted/block.go
@@ -390,24 +390,23 @@ func handleTrailingComma(lgs []*lineGroup) (trimTrailingComma func([]*lineGroup)
 		}
 	}
 
-	commaLineEnd := regexp.MustCompile("(,)( *)((#|//).*)?$")
-	commentLineEnd := regexp.MustCompile("( *)((#|//).*)$")
+	knownCommentMarkersList := knownCommentMarkers()
+	for i, marker := range knownCommentMarkersList {
+		// Some comment markers, such as "/*", include regex metacharacters.
+		knownCommentMarkersList[i] = regexp.QuoteMeta(marker)
+	}
+	knownCommentMarkersStr := strings.Join(knownCommentMarkersList, "|")
+
+	commaLineEnd := regexp.MustCompile(fmt.Sprintf(",(\\s*(%s).*)?$", knownCommentMarkersStr))
+	lineEnd := regexp.MustCompile(fmt.Sprintf("(\\s*(%s).*)?$", knownCommentMarkersStr))
 
 	if n := len(dataGroups); n > 1 && allMatchSuffix(dataGroups[0:n-1], commaLineEnd) && !dataGroups[n-1].matchesSuffix(commaLineEnd) {
-		if dataGroups[n-1].matchesSuffix(commentLineEnd) {
-			dataGroups[n-1].replaceSuffix(commentLineEnd, ", $2")
-		} else {
-			dataGroups[n-1].append(",")
-		}
+		dataGroups[n-1].replaceSuffix(lineEnd, ",$1")
 
 		return func(lgs []*lineGroup) {
 			for i := len(lgs) - 1; i >= 0; i-- {
 				if len(lgs[i].lines) > 0 {
-					if lgs[i].matchesSuffix(commentLineEnd) {
-						lgs[i].replaceSuffix(commaLineEnd, "  $3")
-					} else {
-						lgs[i].trimSuffix(",")
-					}
+					lgs[i].replaceSuffix(commaLineEnd, "$1")
 					return
 				}
 			}

--- a/keepsorted/keep_sorted_test.go
+++ b/keepsorted/keep_sorted_test.go
@@ -1127,6 +1127,21 @@ func TestLineSorting(t *testing.T) {
 			},
 		},
 		{
+			name: "TrailingCommas_WithComments",
+
+			in: []string{
+				"foo,",
+				"baz, /* baz */",
+				"bar // bar",
+			},
+
+			want: []string{
+				"bar, // bar",
+				"baz, /* baz */",
+				"foo",
+			},
+		},
+		{
 			name: "IgnorePrefixes",
 
 			opts: blockOptions{

--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -61,7 +61,7 @@ type accessRecorder struct {
 	joinedComment bool
 }
 
-// matchesAnyRegex returns true if s matchesSuffix one of the regexes.
+// matchesAnyRegex returns true if s matches one of the regexes.
 func matchesAnyRegex(s string, regexes []*regexp.Regexp) bool {
 	for _, regex := range regexes {
 		if regex.FindStringSubmatch(s) != nil {

--- a/keepsorted/line_group.go
+++ b/keepsorted/line_group.go
@@ -61,7 +61,7 @@ type accessRecorder struct {
 	joinedComment bool
 }
 
-// matchesAnyRegex returns true if s matches one of the regexes.
+// matchesAnyRegex returns true if s matchesSuffix one of the regexes.
 func matchesAnyRegex(s string, regexes []*regexp.Regexp) bool {
 	for _, regex := range regexes {
 		if regex.FindStringSubmatch(s) != nil {
@@ -119,7 +119,7 @@ func groupLines(lines []string, metadata blockMetadata) []*lineGroup {
 	// Returns another boolean indicating whether the group should be ending
 	// after that line if so.
 	shouldAddToRegexDelimitedGroup := func(l string) (addToGroup bool, finishGroupAfter bool) {
-        if metadata.opts.GroupStartRegex != nil {
+		if metadata.opts.GroupStartRegex != nil {
 			// For GroupStartRegex, all non-regex-matching lines should be
 			// part of the group including prior lines.
 			return !matchesAnyRegex(l, metadata.opts.GroupStartRegex), false
@@ -408,9 +408,18 @@ func (lg *lineGroup) hasSuffix(s string) bool {
 	return len(lg.lines) > 0 && strings.HasSuffix(lg.lines[len(lg.lines)-1], s)
 }
 
+func (lg *lineGroup) matchesSuffix(re *regexp.Regexp) bool {
+	return len(lg.lines) > 0 && re.MatchString(lg.lines[len(lg.lines)-1])
+}
+
 func (lg *lineGroup) trimSuffix(s string) {
 	lg.access = accessRecorder{}
 	lg.lines[len(lg.lines)-1] = strings.TrimSuffix(lg.lines[len(lg.lines)-1], s)
+}
+
+func (lg *lineGroup) replaceSuffix(re *regexp.Regexp, replacement string) {
+	lg.access = accessRecorder{}
+	lg.lines[len(lg.lines)-1] = re.ReplaceAllString(lg.lines[len(lg.lines)-1], replacement)
 }
 
 func (lg *lineGroup) commentOnly() bool {

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -453,7 +453,7 @@ func (opts blockOptions) hasGroupPrefix(s string) bool {
 }
 
 // trimIgnorePrefix removes the first matching IgnorePrefixes from s, if s
-// matchesSuffix one of the IgnorePrefixes.
+// matches one of the IgnorePrefixes.
 func (opts blockOptions) trimIgnorePrefix(s string) string {
 	_, s, _ = opts.cutFirstPrefix(s, slices.Values(opts.IgnorePrefixes))
 	return s

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -312,9 +312,13 @@ func formatIntList(intVals []int) string {
 	return strings.Join(vals, ",")
 }
 
+func knownCommentMarkers() []string {
+	return []string{"//", "#", "/*", "--", ";", "<!--"}
+}
+
 func guessCommentMarker(startLine string) string {
 	startLine = strings.TrimSpace(startLine)
-	for _, marker := range []string{"//", "#", "/*", "--", ";", "<!--"} {
+	for _, marker := range knownCommentMarkers() {
 		if strings.HasPrefix(startLine, marker) {
 			return marker
 		}

--- a/keepsorted/options.go
+++ b/keepsorted/options.go
@@ -453,7 +453,7 @@ func (opts blockOptions) hasGroupPrefix(s string) bool {
 }
 
 // trimIgnorePrefix removes the first matching IgnorePrefixes from s, if s
-// matches one of the IgnorePrefixes.
+// matchesSuffix one of the IgnorePrefixes.
 func (opts blockOptions) trimIgnorePrefix(s string) string {
 	_, s, _ = opts.cutFirstPrefix(s, slices.Values(opts.IgnorePrefixes))
 	return s


### PR DESCRIPTION
Issue: https://github.com/google/keep-sorted/issues/33

For lines/sequences of blocks which appear to be a comma-delimited list, do not consider comments when performing this check. Also, insert commas before comments to avoid mangling list entries.

I put the match/replace logic in lineGroup, as hasSuffix/trimSuffix were there.

This approach does have a few weaknesses. It doesn't properly handle sorting entries with quoted comment characters, e.g.:

```
  "c",
  "b, //",
  "a, #"
```

It is better at handling the desired cases, and the above counterexamples where it fails feel more like less-common edge cases. Importantly though - with the preexisting logic, the above would be handled correctly, but now would not be.

Lastly, it always tries to match all comment types. So even if "#" isn't a valid comment character in the context, it will still try to use it. I attempted an approach that used the opt.commentMarker, but that is often not set in tests. I could go and add it to existing tests where it matters, and then we could assume from how the blocks are defined which comment markers are relevant. This would get closer to handling the above well.

Fully "correctly" handling the above would need a bit more work - likely parsing the lines themselves and adding quote_delimiter and/or comment_delimiter options.