### PR TITLE
feat: add multi-architecture release artifacts

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -8,15 +8,28 @@ jobs:
   build-and-upload:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            suffix: linux
-          - os: windows-latest
-            suffix: windows
-            extension: .exe
+            goos: linux
+            goarch: amd64
+            suffix: linux_amd64
+          - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+            suffix: linux_arm64
           - os: macos-latest
-            suffix: darwin
+            goos: darwin
+            goarch: amd64
+            suffix: darwin_amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+            suffix: darwin_arm64
+          - os: windows-latest
+            goos: windows
+            goarch: amd64
+            suffix: windows_amd64
+            extension: .exe
 
     runs-on: ${{matrix.os}}
 
@@ -33,7 +46,11 @@ jobs:
           go-version: "1.23"
 
       - name: Build
-        run: go build -v .
+        run: go build -v -o keep-sorted${{matrix.extension}} .
+        env:
+          GOOS: ${{matrix.goos}}
+          GOARCH: ${{matrix.goarch}}
+          CGO_ENABLED: "0"
 
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -12,23 +12,18 @@ jobs:
           - os: ubuntu-latest
             goos: linux
             goarch: amd64
-            suffix: linux_amd64
           - os: ubuntu-latest
             goos: linux
             goarch: arm64
-            suffix: linux_arm64
           - os: macos-latest
             goos: darwin
             goarch: amd64
-            suffix: darwin_amd64
           - os: macos-latest
             goos: darwin
             goarch: arm64
-            suffix: darwin_arm64
           - os: windows-latest
             goos: windows
             goarch: amd64
-            suffix: windows_amd64
             extension: .exe
 
     runs-on: ${{matrix.os}}
@@ -57,9 +52,9 @@ jobs:
 
       - name: Upload Artifacts to Release
         run: |
-          echo Uploading ${{matrix.suffix}} artifact for ${GITHUB_REF_NAME}
-          mv keep-sorted${{matrix.extension}} keep-sorted_${{matrix.suffix}}${{matrix.extension}}
-          gh release upload ${GITHUB_REF_NAME} keep-sorted_${{matrix.suffix}}${{matrix.extension}} --clobber
+          echo Uploading ${{matrix.goos}}_${{matrix.goarch}} artifact for ${GITHUB_REF_NAME}
+          mv keep-sorted${{matrix.extension}} keep-sorted_${{matrix.goos}}_${{matrix.goarch}}${{matrix.extension}}
+          gh release upload ${GITHUB_REF_NAME} keep-sorted_${{matrix.goos}}_${{matrix.goarch}}${{matrix.extension}} --clobber
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Add explicit `GOOS`/`GOARCH` cross-compilation to the release workflow
- Produce binaries for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`
- Set `CGO_ENABLED=0` and use explicit `-o` flag for consistent output naming
- Artifact names now include architecture (e.g. `keep-sorted_linux_amd64` instead of `keep-sorted_linux`)

## Motivation

The current workflow builds one binary per OS using the runner's native architecture. With GitHub Actions runners moving to arm64 for macOS, there's no `darwin/amd64` binary for Intel Macs, and there has never been a `linux/arm64` binary.

## Breaking change

Artifact names change from `keep-sorted_<os>` to `keep-sorted_<os>_<arch>`. Users scripting downloads against the old names will need to update.

## Test plan

- [x] Verify the workflow YAML is valid
- [x] Trigger a test release on the fork to confirm all 5 matrix jobs produce correctly named binaries
- [x] Verify cross-compiled binaries with `file` command (ELF ARM aarch64, Mach-O x86_64, etc.)